### PR TITLE
Generate .displayxr.json app manifest sidecar on build

### DIFF
--- a/Editor/DisplayXRBuildProcessor.cs
+++ b/Editor/DisplayXRBuildProcessor.cs
@@ -1,0 +1,148 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+
+using System.IO;
+using System.Text;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace DisplayXR.Editor
+{
+    /// <summary>
+    /// Post-build processor that generates a .displayxr.json sidecar file
+    /// next to the built executable. The DisplayXR shell's spatial launcher
+    /// scans for these files to discover installed apps.
+    /// </summary>
+    public class DisplayXRBuildProcessor : IPostprocessBuildWithReport
+    {
+        public int callbackOrder => 100;
+
+        public void OnPostprocessBuild(BuildReport report)
+        {
+            string exePath = report.summary.outputPath;
+            string exeDir = Path.GetDirectoryName(exePath);
+            string exeName = Path.GetFileNameWithoutExtension(exePath);
+            string sidecarPath = Path.Combine(exeDir, exeName + ".displayxr.json");
+
+            var settings = DisplayXRManifestSettings.Find();
+
+            // Resolve values — use settings if available, otherwise defaults
+            string appName = settings != null ? settings.EffectiveName : Application.productName;
+            string category = settings != null ? settings.category.ToString() : "app";
+            string displayMode = settings != null ? settings.displayMode : "auto";
+            string description = settings != null ? settings.description : "";
+
+            // Build JSON
+            var sb = new StringBuilder();
+            sb.AppendLine("{");
+            sb.AppendLine("  \"schema_version\": 1,");
+            sb.AppendLine($"  \"name\": {JsonEscape(appName)},");
+            sb.Append($"  \"type\": \"3d\"");
+
+            // Optional fields — only include non-default values
+            if (category != "app")
+            {
+                sb.AppendLine(",");
+                sb.Append($"  \"category\": {JsonEscape(category)}");
+            }
+            if (displayMode != "auto")
+            {
+                sb.AppendLine(",");
+                sb.Append($"  \"display_mode\": {JsonEscape(displayMode)}");
+            }
+            if (!string.IsNullOrEmpty(description))
+            {
+                string truncated = description.Length > 256 ? description.Substring(0, 256) : description;
+                sb.AppendLine(",");
+                sb.Append($"  \"description\": {JsonEscape(truncated)}");
+            }
+
+            // Export icon textures if assigned
+            if (settings != null && settings.icon != null)
+            {
+                string iconFile = "icon.png";
+                if (ExportTexture(settings.icon, Path.Combine(exeDir, iconFile)))
+                {
+                    sb.AppendLine(",");
+                    sb.Append($"  \"icon\": {JsonEscape(iconFile)}");
+                }
+            }
+            if (settings != null && settings.icon3D != null)
+            {
+                string icon3DFile = "icon_sbs.png";
+                if (ExportTexture(settings.icon3D, Path.Combine(exeDir, icon3DFile)))
+                {
+                    sb.AppendLine(",");
+                    sb.Append($"  \"icon_3d\": {JsonEscape(icon3DFile)}");
+                    string layout = DisplayXRManifestSettings.LayoutToString(settings.icon3DLayout);
+                    if (layout != "sbs-lr")
+                    {
+                        sb.AppendLine(",");
+                        sb.Append($"  \"icon_3d_layout\": {JsonEscape(layout)}");
+                    }
+                }
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("}");
+
+            File.WriteAllText(sidecarPath, sb.ToString(), Encoding.UTF8);
+            Debug.Log($"DisplayXR: Generated app manifest at {sidecarPath}");
+        }
+
+        /// <summary>
+        /// Export a texture to PNG, handling non-readable textures via GPU readback.
+        /// </summary>
+        private static bool ExportTexture(Texture2D source, string destPath)
+        {
+            try
+            {
+                byte[] png;
+                if (source.isReadable)
+                {
+                    png = source.EncodeToPNG();
+                }
+                else
+                {
+                    // GPU readback for non-readable textures
+                    var rt = RenderTexture.GetTemporary(source.width, source.height, 0, RenderTextureFormat.ARGB32);
+                    Graphics.Blit(source, rt);
+                    var prev = RenderTexture.active;
+                    RenderTexture.active = rt;
+                    var readable = new Texture2D(source.width, source.height, TextureFormat.RGBA32, false);
+                    readable.ReadPixels(new Rect(0, 0, source.width, source.height), 0, 0);
+                    readable.Apply();
+                    RenderTexture.active = prev;
+                    RenderTexture.ReleaseTemporary(rt);
+                    png = readable.EncodeToPNG();
+                    Object.DestroyImmediate(readable);
+                }
+
+                if (png == null || png.Length == 0)
+                    return false;
+
+                File.WriteAllBytes(destPath, png);
+                return true;
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"DisplayXR: Failed to export icon to {destPath}: {e.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>JSON-escape a string value with surrounding quotes.</summary>
+        private static string JsonEscape(string value)
+        {
+            if (value == null) return "\"\"";
+            return "\"" + value
+                .Replace("\\", "\\\\")
+                .Replace("\"", "\\\"")
+                .Replace("\n", "\\n")
+                .Replace("\r", "\\r")
+                .Replace("\t", "\\t")
+                + "\"";
+        }
+    }
+}

--- a/Editor/DisplayXRBuildProcessor.cs.meta
+++ b/Editor/DisplayXRBuildProcessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 997720d28104f45a6baa24ffc0f995bb

--- a/Editor/DisplayXRManifestSettings.cs
+++ b/Editor/DisplayXRManifestSettings.cs
@@ -1,0 +1,85 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+
+using UnityEngine;
+
+namespace DisplayXR.Editor
+{
+    /// <summary>
+    /// Project-level settings for the .displayxr.json app manifest sidecar
+    /// generated alongside built executables. The DisplayXR shell's spatial
+    /// launcher uses this file to discover and display installed apps.
+    /// </summary>
+    public class DisplayXRManifestSettings : ScriptableObject
+    {
+        private const string AssetPath = "Assets/DisplayXRManifestSettings.asset";
+
+        public enum AppCategory { app, demo, test, tool }
+        public enum StereoLayout { sbs_lr, sbs_rl, tb, bt }
+
+        [Tooltip("Display name shown on the launcher tile. Leave empty to use Application.productName.")]
+        public string appName = "";
+
+        [Tooltip("Free-form category tag for the launcher.")]
+        public AppCategory category = AppCategory.app;
+
+        [Tooltip("Preferred display rendering mode at launch.")]
+        public string displayMode = "auto";
+
+        [Tooltip("One-line description for tooltips (max 256 chars).")]
+        [TextArea(1, 3)]
+        public string description = "";
+
+        [Tooltip("2D tile icon (PNG, 512x512 recommended). Leave empty for text-only tile.")]
+        public Texture2D icon;
+
+        [Tooltip("Stereoscopic side-by-side tile icon (1024x512 recommended). Enables 3D tile in launcher.")]
+        public Texture2D icon3D;
+
+        [Tooltip("How the stereo pair is packed in the 3D icon.")]
+        public StereoLayout icon3DLayout = StereoLayout.sbs_lr;
+
+        /// <summary>Effective app name: explicit setting or fallback to product name.</summary>
+        public string EffectiveName =>
+            string.IsNullOrWhiteSpace(appName) ? Application.productName : appName;
+
+        /// <summary>Convert StereoLayout enum to the JSON string value.</summary>
+        public static string LayoutToString(StereoLayout layout)
+        {
+            switch (layout)
+            {
+                case StereoLayout.sbs_lr: return "sbs-lr";
+                case StereoLayout.sbs_rl: return "sbs-rl";
+                case StereoLayout.tb:     return "tb";
+                case StereoLayout.bt:     return "bt";
+                default:                  return "sbs-lr";
+            }
+        }
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Load the settings asset, or create one if it doesn't exist.
+        /// </summary>
+        public static DisplayXRManifestSettings GetOrCreate()
+        {
+            var settings = UnityEditor.AssetDatabase.LoadAssetAtPath<DisplayXRManifestSettings>(AssetPath);
+            if (settings != null)
+                return settings;
+
+            settings = CreateInstance<DisplayXRManifestSettings>();
+            UnityEditor.AssetDatabase.CreateAsset(settings, AssetPath);
+            UnityEditor.AssetDatabase.SaveAssets();
+            return settings;
+        }
+
+        /// <summary>
+        /// Try to load existing settings. Returns null if no asset exists.
+        /// Does not create a new asset.
+        /// </summary>
+        public static DisplayXRManifestSettings Find()
+        {
+            return UnityEditor.AssetDatabase.LoadAssetAtPath<DisplayXRManifestSettings>(AssetPath);
+        }
+#endif
+    }
+}

--- a/Editor/DisplayXRManifestSettings.cs.meta
+++ b/Editor/DisplayXRManifestSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4698243b835c4ace84ef7ee77d67400

--- a/Editor/DisplayXRManifestSettingsEditor.cs
+++ b/Editor/DisplayXRManifestSettingsEditor.cs
@@ -1,0 +1,95 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+
+using UnityEditor;
+using UnityEngine;
+
+namespace DisplayXR.Editor
+{
+    [CustomEditor(typeof(DisplayXRManifestSettings))]
+    public class DisplayXRManifestSettingsEditor : UnityEditor.Editor
+    {
+        private SerializedProperty appName;
+        private SerializedProperty category;
+        private SerializedProperty displayMode;
+        private SerializedProperty description;
+        private SerializedProperty icon;
+        private SerializedProperty icon3D;
+        private SerializedProperty icon3DLayout;
+
+        private void OnEnable()
+        {
+            appName = serializedObject.FindProperty("appName");
+            category = serializedObject.FindProperty("category");
+            displayMode = serializedObject.FindProperty("displayMode");
+            description = serializedObject.FindProperty("description");
+            icon = serializedObject.FindProperty("icon");
+            icon3D = serializedObject.FindProperty("icon3D");
+            icon3DLayout = serializedObject.FindProperty("icon3DLayout");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+
+            EditorGUILayout.HelpBox(
+                "These settings control the .displayxr.json sidecar file generated " +
+                "next to your built executable. The DisplayXR shell's spatial launcher " +
+                "uses this file to discover and display your app.",
+                MessageType.Info);
+
+            EditorGUILayout.Space();
+
+            // --- Required ---
+            EditorGUILayout.LabelField("Required", EditorStyles.boldLabel);
+
+            EditorGUILayout.PropertyField(appName, new GUIContent("App Name",
+                "Display name on the launcher tile. Leave empty to use Application.productName."));
+            if (string.IsNullOrWhiteSpace(appName.stringValue))
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.LabelField("Default", Application.productName, EditorStyles.miniLabel);
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.LabelField("Type", "3d (always for Unity apps)", EditorStyles.miniLabel);
+
+            EditorGUILayout.Space();
+
+            // --- Optional ---
+            EditorGUILayout.LabelField("Optional", EditorStyles.boldLabel);
+
+            EditorGUILayout.PropertyField(category, new GUIContent("Category"));
+            EditorGUILayout.PropertyField(displayMode, new GUIContent("Display Mode",
+                "Preferred display rendering mode at launch."));
+            EditorGUILayout.PropertyField(description, new GUIContent("Description",
+                "One-line description for tooltips (max 256 chars)."));
+            if (description.stringValue.Length > 256)
+            {
+                EditorGUILayout.HelpBox(
+                    $"Description is {description.stringValue.Length} chars (max 256). It will be truncated on build.",
+                    MessageType.Warning);
+            }
+
+            EditorGUILayout.Space();
+
+            // --- Icons ---
+            EditorGUILayout.LabelField("Icons", EditorStyles.boldLabel);
+
+            EditorGUILayout.PropertyField(icon, new GUIContent("2D Icon",
+                "PNG tile icon (512x512 recommended)."));
+
+            EditorGUILayout.PropertyField(icon3D, new GUIContent("3D SBS Icon",
+                "Stereoscopic side-by-side tile icon (1024x512 recommended). Enables 3D tile in launcher."));
+
+            if (icon3D.objectReferenceValue != null)
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PropertyField(icon3DLayout, new GUIContent("Stereo Layout"));
+                EditorGUI.indentLevel--;
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Editor/DisplayXRManifestSettingsEditor.cs.meta
+++ b/Editor/DisplayXRManifestSettingsEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6fb8edf72119443a9810ec964d755dfd

--- a/Editor/DisplayXRSettingsProvider.cs
+++ b/Editor/DisplayXRSettingsProvider.cs
@@ -48,6 +48,11 @@ namespace DisplayXR.Editor
 
             // Feature status
             DrawFeatureStatus();
+
+            EditorGUILayout.Space();
+
+            // App manifest sidecar
+            DrawManifestSection();
         }
 
         private void DrawRuntimeStatus()
@@ -168,6 +173,34 @@ namespace DisplayXR.Editor
             else
             {
                 EditorGUILayout.LabelField("Connected", "No (display info not available)");
+            }
+
+            EditorGUILayout.EndVertical();
+        }
+
+        private void DrawManifestSection()
+        {
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            EditorGUILayout.LabelField("App Manifest", EditorStyles.boldLabel);
+
+            EditorGUILayout.HelpBox(
+                "The DisplayXR launcher discovers apps via a .displayxr.json sidecar file " +
+                "generated next to each built executable. Configure the manifest settings below.",
+                MessageType.Info);
+
+            var settings = DisplayXRManifestSettings.Find();
+            if (settings != null)
+            {
+                EditorGUILayout.LabelField("App Name", settings.EffectiveName);
+                EditorGUILayout.LabelField("Category", settings.category.ToString());
+                if (GUILayout.Button("Select Manifest Settings"))
+                    Selection.activeObject = settings;
+            }
+            else
+            {
+                EditorGUILayout.LabelField("Status", "No settings asset (defaults will be used on build)");
+                if (GUILayout.Button("Create Manifest Settings"))
+                    Selection.activeObject = DisplayXRManifestSettings.GetOrCreate();
             }
 
             EditorGUILayout.EndVertical();


### PR DESCRIPTION
## Summary
- Adds `IPostprocessBuildWithReport` that writes a `.displayxr.json` sidecar file next to the built executable, enabling the DisplayXR shell launcher to discover Unity apps
- Adds `DisplayXRManifestSettings` ScriptableObject for configuring app name, category, display mode, description, and 2D/3D icons
- Adds "App Manifest" section to the DisplayXR settings page for creating/selecting the settings asset
- When no settings asset exists, sensible defaults are used (product name, type "3d")

Closes #51

## Test plan
- [x] Built Windows target from Unity CLI — sidecar generated correctly next to `.exe`
- [x] Verified JSON content: `schema_version: 1`, `name` from `Application.productName`, `type: "3d"`
- [x] Verified default behavior (no settings asset) works without errors
- [ ] Test with custom `DisplayXRManifestSettings` asset (icons, category, description)
- [ ] Verify settings page shows "App Manifest" section with create/select button

🤖 Generated with [Claude Code](https://claude.com/claude-code)