### PR TITLE
Add chromaKeyColor property setter, switch sample to gray key (#57)

### DIFF
--- a/Runtime/DisplayXRTransparentOverlay.cs
+++ b/Runtime/DisplayXRTransparentOverlay.cs
@@ -3,6 +3,7 @@
 
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.Serialization;
 #if HAS_INPUT_SYSTEM
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.LowLevel;
@@ -53,7 +54,29 @@ namespace DisplayXR
                  "pixels before Present so DComp/DWM blends per-pixel. " +
                  "Magenta (1,0,1) is the standard pick — pure primary, no " +
                  "sRGB round-trip drift, unlikely to appear in real content.")]
-        public Color chromaKeyColor = new Color(1f, 0f, 1f, 0f);
+        [SerializeField, FormerlySerializedAs("chromaKeyColor")]
+        private Color m_ChromaKeyColor = new Color(1f, 0f, 1f, 0f);
+
+        /// <summary>
+        /// Color rendered in transparent regions. Assignment at runtime is
+        /// safe: the setter immediately re-pushes the new color to both the
+        /// camera clear and the native overlay (LWA_COLORKEY + win32 binding),
+        /// so all three sides — camera clear, layered-window key, runtime
+        /// post-weave — stay in sync without toggling the component.
+        ///
+        /// If you change this from the Inspector at runtime, OnValidate
+        /// re-applies. Pre-build / authoring-time changes are picked up by
+        /// OnEnable as before.
+        /// </summary>
+        public Color chromaKeyColor
+        {
+            get => m_ChromaKeyColor;
+            set
+            {
+                m_ChromaKeyColor = value;
+                ApplyChromaKey();
+            }
+        }
 
         [Header("Window")]
 
@@ -440,6 +463,40 @@ namespace DisplayXR
                 m_Camera.backgroundColor = m_SavedBackgroundColor;
                 m_SavedRestore = false;
             }
+        }
+
+        // Re-apply the current chroma-key color to the camera clear and the
+        // native overlay. Idempotent — safe to call any time. Early-outs
+        // before OnEnable has run (m_SavedRestore is false): OnEnable will
+        // pick up m_ChromaKeyColor itself and the explicit re-push isn't
+        // needed.
+        private void ApplyChromaKey()
+        {
+            if (!m_SavedRestore || m_Camera == null)
+                return;
+
+            m_Camera.backgroundColor = m_ChromaKeyColor;
+
+#if UNITY_STANDALONE_WIN
+            // Editor preview path skips the layered-window plumbing entirely
+            // (see OnEnable); same gate here.
+            if (Application.isEditor)
+                return;
+            if (!enabled || !gameObject.activeInHierarchy)
+                return;
+            DisplayXRNative.displayxr_set_transparent_overlay(
+                1, ColorRefFromColor(m_ChromaKeyColor),
+                alwaysOnTop ? 1 : 0);
+#endif
+        }
+
+        // Inspector-driven changes go straight to the SerializeField backing
+        // and bypass the property setter, so re-apply manually during Play.
+        // Edit-mode changes fall through to the OnEnable path on next Play.
+        void OnValidate()
+        {
+            if (Application.isPlaying)
+                ApplyChromaKey();
         }
 
         // Pack a Unity Color into a Windows COLORREF (0x00BBGGRR).

--- a/Samples~/TransparentAvatar/README.md
+++ b/Samples~/TransparentAvatar/README.md
@@ -9,11 +9,20 @@ Issue: [#57 — Add transparent overlay mode for desktop avatar use case](https:
 
 The Leia weaver writes opaque RGB only and the DisplayXR D3D11 compositor uses
 `DXGI_ALPHA_MODE_IGNORE`, so per-pixel alpha doesn't survive end-to-end.
-Workaround: render a magic color (default magenta `RGB(255, 0, 255)`) in
-transparent regions of *both* eye views. Because `L == R` per sub-pixel in
-those regions, the weaver passes the magic color through unchanged. Then
-`WS_EX_LAYERED + LWA_COLORKEY` on the top-level HWND tells DWM to punch those
-pixels through to the desktop and route mouse input below.
+Workaround: render a magic color in transparent regions of *both* eye views.
+Because `L == R` per sub-pixel in those regions, the weaver passes the magic
+color through unchanged. Then `WS_EX_LAYERED + LWA_COLORKEY` on the top-level
+HWND tells DWM to punch those pixels through to the desktop and route mouse
+input below.
+
+This sample uses **near-mid-gray `RGB(128, 127, 129)`** instead of the more
+conventional magenta. Both work as keys; gray makes the silhouette-edge halo
+(anti-aliased pixels that partially blend the key color) blend invisibly into
+typical desktop backgrounds, while magenta produces a visible pink fringe.
+Trade-off: avatar materials must avoid `(128, 127, 129)` ±1 — any pixel that
+happens to land exactly on the key after weaving will go transparent. Pure
+magenta is unlikely to appear in real content, gray is not, so be aware of
+the avatar palette.
 
 Full chroma-key rationale, math, and ACT (anti-crosstalk) interactions:
 `displayxr-runtime:docs/reference/chroma-key-transparent-overlay.md`.
@@ -31,25 +40,29 @@ Full chroma-key rationale, math, and ACT (anti-crosstalk) interactions:
 2. Create an empty scene, add an empty GameObject, attach `TransparentAvatarSetup`.
 3. **Build a Windows standalone player** — the layered-window path only runs
    in a build, not in the editor preview.
-4. Run on a Leia SR machine. The capsule appears above the desktop; magenta is
-   invisible (DWM punches it).
+4. Run on a Leia SR machine. The capsule appears above the desktop; the gray
+   chroma key is invisible (DWM punches it).
 
 ## Verification checklist
 
-- Capsule renders with no rectangular background — magenta is gone.
-- Clicks on magenta land on the underlying app (taskbar, browser).
+- Capsule renders with no rectangular background — the chroma key is gone.
+- Clicks on the chroma-key region land on the underlying app (taskbar, browser).
 - Clicks on the capsule reach Unity (`OnMouseDown` fires).
 - Capsule pops convincingly in stereo. Transparent regions stay clean
   (no shimmer, `L == R`).
+- No speckle holes inside the capsule (would mean avatar pixels are landing
+  exactly on `(128, 127, 129)` — adjust palette or tweak the chroma color).
 
 ## Known limitations (v1)
 
 - Rectangular hit-test (bounding box) only. Per-pixel alpha-mask hit-testing
   is a future upgrade.
-- Silhouette edges may show a chroma halo. Mitigation: feathered magenta
-  border in shader, or fall back to `SetWindowRgn` for a hard polygonal cutout.
+- Silhouette edges may show a faint chroma halo. With the gray key it's
+  usually invisible; with a saturated key (e.g. magenta) you'd want a
+  feathered border shader or `SetWindowRgn` for a hard polygonal cutout.
 - Don't include the chroma-key color in the avatar's palette — clamp shader
-  outputs near it.
+  outputs near it. With a gray key the constraint is meaningful (gray is
+  common in lit 3D scenes); with magenta it was nearly free.
 - Fullscreen-exclusive games hide topmost layered windows. Document, don't fix.
 - Windows only for v1. macOS equivalent (`NSWindow.isOpaque = NO` +
   `CAColorMatrixFilter`) is a TODO.

--- a/Samples~/TransparentAvatar/TransparentAvatarSetup.cs
+++ b/Samples~/TransparentAvatar/TransparentAvatarSetup.cs
@@ -25,6 +25,25 @@ namespace DisplayXR.Samples
         [Tooltip("Breathing animation frequency in Hz.")]
         public float breathRate = 0.4f;
 
+        // Chroma-key color used for both the camera clear (LWA_COLORKEY
+        // punch-through) and the runtime's post-weave alpha-conversion pass
+        // (spec v5). Near-mid-gray instead of magenta so silhouette-edge
+        // halos blend invisibly into typical desktop / photo backgrounds.
+        // Trade-off: avatar pixels that land exactly on this color go
+        // transparent — keep the avatar palette clear of (128,127,129).
+        static readonly Color s_ChromaKey = new Color(128f / 255f, 127f / 255f, 129f / 255f, 0f);
+
+        // Must fire BEFORE xrCreateSession so the runtime sees the chroma
+        // color when the win32 window-binding extension is wired up;
+        // RequestTransparentSession + RequestChromaKey both write to plugin
+        // shared state that's read in xrCreateSession.
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void EnableTransparentSession()
+        {
+            DisplayXR.DisplayXRTransparentOverlay.RequestTransparentSession();
+            DisplayXR.DisplayXRTransparentOverlay.RequestChromaKey(s_ChromaKey);
+        }
+
         private GameObject m_Capsule;
         private Vector3 m_BaseScale;
 
@@ -64,10 +83,13 @@ namespace DisplayXR.Samples
             light.type = LightType.Directional;
             lightGo.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
 
-            // Transparent overlay + chroma-key background.
+            // Transparent overlay + chroma-key background. Override the
+            // component default (magenta) with the same gray we requested
+            // statically above — both sides must agree on the key color.
             var overlay = cam.gameObject.GetComponent<DisplayXR.DisplayXRTransparentOverlay>();
             if (overlay == null)
                 overlay = cam.gameObject.AddComponent<DisplayXR.DisplayXRTransparentOverlay>();
+            overlay.chromaKeyColor = s_ChromaKey;
             overlay.clickableRenderers = new Renderer[] { m_Capsule.GetComponent<Renderer>() };
         }
 


### PR DESCRIPTION
## Summary

- `DisplayXRTransparentOverlay.chromaKeyColor` is now a property over a private `SerializeField` backing. The setter re-pushes the new color to camera clear + native overlay (`displayxr_set_transparent_overlay`) so all three sides — Unity camera clear, Win32 `LWA_COLORKEY`, runtime post-weave — stay in sync without the user toggling the component.
- Backing field uses `[FormerlySerializedAs(\"chromaKeyColor\")]` so existing scenes/prefabs deserialize unchanged. Inspector still labels it "Chroma Key Color" (Unity strips `m_`).
- `OnValidate()` re-applies on Inspector edits during Play.
- `Samples~/TransparentAvatar` switches default key to `RGB(128, 127, 129)` (near-mid-gray) so silhouette-edge halos blend invisibly into typical desktop backgrounds. README updated with rationale + the new trade-off (avatar palette must avoid the key color).

## Why

When a user does:

```csharp
overlay = cam.gameObject.AddComponent<DisplayXRTransparentOverlay>();
overlay.chromaKeyColor = customColor;
```

`AddComponent` invokes `OnEnable` synchronously, which reads the field as the magenta default and pushes magenta to camera clear + `LWA_COLORKEY`. The post-assignment value of `customColor` only landed in the runtime post-weave pass via the static `RequestChromaKey` (if called). Mismatch → magenta still visible despite the assignment.

The property setter pattern fixes this generically — assignment now triggers `ApplyChromaKey()` which re-pushes the runtime-mutable state.

## Test plan

- [ ] CI green on this PR (Windows x64 + macOS Universal)
- [ ] Local rebuild of `displayxr-unity-test-transparent` (links via `file:../../unity-3d-display`) shows `chromaKeyColor=0x00818081` in `displayxr.log` instead of `0x00FF00FF`
- [ ] Avatar capsule renders with no rectangular background, no visible silhouette halo against a typical desktop
- [ ] Click-through still works (regression check vs. v1.2.0 #57 functionality)
- [ ] Scenes/prefabs with the old `chromaKeyColor: {...}` YAML key still deserialize correctly (FormerlySerializedAs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)