### PR TITLE
Fix Unity 6 compile error in DiscoverCameras (#3)

### DIFF
--- a/Editor/DisplayXRPreviewSession.cs
+++ b/Editor/DisplayXRPreviewSession.cs
@@ -669,7 +669,7 @@ namespace DisplayXR.Editor
 
         public static CameraEntry[] DiscoverCameras()
         {
-            var cameras = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsInactive.Exclude);
+            var cameras = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
             var entries = new List<CameraEntry>();
 
             foreach (var cam in cameras)


### PR DESCRIPTION
## Summary
- `FindObjectsByType<T>(FindObjectsInactive)` single-arg overload was removed in Unity 6, breaking compilation. Pass explicit `FindObjectsSortMode.None` so the call binds to the two-arg overload, which exists on both 2022.3 and Unity 6.

Surfaced while loading LeiaViewer-DisplayXR under Unity 6 — see issue #3.

## Test plan
- [ ] CI green on PR head (2022.3 build succeeds)
- [ ] Re-import LeiaViewer-DisplayXR in Unity 6 batchmode after merge — confirm the `DisplayXRPreviewSession.cs(672)` error is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)