### PR TITLE
Fix URP/Lit shader stripping in builds + document macOS signing (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,37 @@ Set before launching the app:
 export XR_RUNTIME_JSON=/path/to/DisplayXR-macOS/share/openxr/1/openxr_displayxr.json
 ```
 
+#### Unsigned builds and the runtime symlink
+
+If you have a runtime symlink at `~/Library/Application Support/openxr/1/active_runtime.json` (the OpenXR loader's standard discovery path), it works for the Unity editor but **not for unsigned built `.app` bundles**. macOS' file-access protections block unsigned apps from reading other apps' Application Support directories, so the loader can't find the runtime manifest. Symptom:
+
+```
+Loading OpenXR loader library at path: openxr_loader
+[XR] [FAILURE] xrCreateInstance: XR_ERROR_RUNTIME_UNAVAILABLE
+[DisplayXR] DisplayXRFeature not active.
+```
+
+Two ways around it:
+
+**1. Set `XR_RUNTIME_JSON` explicitly when launching** (works with any build, signed or not):
+```bash
+XR_RUNTIME_JSON=/path/to/openxr_displayxr.json /path/to/MyApp.app/Contents/MacOS/MyApp
+```
+
+**2. Code-sign the `.app`** so macOS grants it normal user-file access. Ad-hoc signing is enough for local development — no Apple Developer account needed:
+```bash
+codesign --deep --force --sign - MyApp.app
+```
+After signing, the runtime symlink is reachable and you can launch the app without `XR_RUNTIME_JSON`.
+
+For distributing to other users, sign with a Developer ID and notarize:
+```bash
+codesign --deep --force --sign "Developer ID Application: Your Name (TEAMID)" \
+         --options runtime --timestamp MyApp.app
+xcrun notarytool submit MyApp.app --apple-id you@example.com --team-id TEAMID --wait
+xcrun stapler staple MyApp.app
+```
+
 ### What Happens Without the Runtime
 
 If the DisplayXR runtime is not installed, Unity's OpenXR loader fails to find a runtime and logs:
@@ -397,6 +428,7 @@ This lets you develop and test the full stereo pipeline on any machine.
 | UPM "cannot add package from git URL" (Windows) | Git not installed or not in PATH | Install [Git for Windows](https://gitforwindows.org/), restart Unity. Verify with `git --version` in a terminal. |
 | UPM "cannot add package from git URL" (macOS) | GUI apps can't find Homebrew Git | Run `xcode-select --install` to set up `/usr/bin/git`, or launch Unity from terminal (`open -a Unity`). Check `~/Library/Logs/Unity/upm.log` for details. |
 | `DllNotFoundException: displayxr_unity` | Native plugin not found by Unity | Ensure the plugin binaries are in `Runtime/Plugins/Windows/x64/` or `Runtime/Plugins/macOS/` |
+| macOS: `XR_ERROR_RUNTIME_UNAVAILABLE` in built `.app` despite the symlink working in editor | Unsigned `.app` bundles can't read `~/Library/Application Support/openxr/` due to macOS sandbox protections | Either set `XR_RUNTIME_JSON` when launching, or ad-hoc sign with `codesign --deep --force --sign - MyApp.app`. See [macOS Deployment](#macos-deployment). |
 | HDRP stereo artifacts | Single-pass instanced issue | Verify both eye views have correct FOVs in Frame Debugger |
 | Preview shows "Not Connected" | `XR_RUNTIME_JSON` not set or runtime not running | Set the env var before launching Unity; verify the runtime process is active |
 | Preview shows black after Start | Runtime connected but no output | Check runtime logs; verify sim_display or hardware is configured |

--- a/Samples~/URPBasicScene/Editor/URPBasicSceneShaderRegistration.cs
+++ b/Samples~/URPBasicScene/Editor/URPBasicSceneShaderRegistration.cs
@@ -1,0 +1,69 @@
+// Copyright 2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+
+#if UNITY_EDITOR
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace DisplayXR.Samples.Editor
+{
+    /// <summary>
+    /// Ensures URP/Lit is registered in Project Settings > Graphics > Always Included
+    /// Shaders before any build. URPBasicSceneSetup resolves URP/Lit at runtime via
+    /// Shader.Find, which Unity's build-time shader stripper can't see — without a
+    /// static reference, URP/Lit is dropped from standalone builds and the sample
+    /// renders as the magenta error material. (Issue #72.)
+    ///
+    /// Hook is also exposed as a menu item so users can register manually without
+    /// triggering a build.
+    /// </summary>
+    class URPBasicSceneShaderRegistration : IPreprocessBuildWithReport
+    {
+        const string ShaderName = "Universal Render Pipeline/Lit";
+
+        public int callbackOrder => 0;
+
+        public void OnPreprocessBuild(BuildReport report) => Register();
+
+        [MenuItem("Tools/DisplayXR/Register URP∕Lit in Always Included Shaders")]
+        static void RegisterMenu() => Register();
+
+        static void Register()
+        {
+            var shader = Shader.Find(ShaderName);
+            if (shader == null)
+            {
+                Debug.LogWarning($"[URPBasicScene] Cannot register '{ShaderName}': shader not found. Is URP installed?");
+                return;
+            }
+
+            var assets = AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/GraphicsSettings.asset");
+            if (assets == null || assets.Length == 0)
+            {
+                Debug.LogWarning("[URPBasicScene] Cannot load GraphicsSettings.asset.");
+                return;
+            }
+
+            var so = new SerializedObject(assets[0]);
+            var includedShaders = so.FindProperty("m_AlwaysIncludedShaders");
+            if (includedShaders == null) return;
+
+            for (int i = 0; i < includedShaders.arraySize; i++)
+            {
+                if (includedShaders.GetArrayElementAtIndex(i).objectReferenceValue == shader)
+                    return;
+            }
+
+            int idx = includedShaders.arraySize;
+            includedShaders.InsertArrayElementAtIndex(idx);
+            includedShaders.GetArrayElementAtIndex(idx).objectReferenceValue = shader;
+            so.ApplyModifiedProperties();
+            AssetDatabase.SaveAssets();
+
+            Debug.Log($"[URPBasicScene] Registered '{ShaderName}' in Project Settings > Graphics > Always Included Shaders so it ships in standalone builds.");
+        }
+    }
+}
+#endif

--- a/Samples~/URPBasicScene/README.md
+++ b/Samples~/URPBasicScene/README.md
@@ -13,6 +13,14 @@ fall back to mono.
 
 - `URPBasicSceneSetup.cs` — Spawns colored cubes at varying depths using
   the URP/Lit shader. Attach to any GameObject in a fresh scene.
+- `Editor/URPBasicSceneShaderRegistration.cs` — Editor-only. Before any
+  standalone build (via `IPreprocessBuildWithReport`) and on demand via
+  **Tools > DisplayXR > Register URP/Lit in Always Included Shaders**, adds
+  URP/Lit to **Project Settings > Graphics > Always Included Shaders** so the
+  shader ships in standalone builds. Without this, Unity's build-time shader
+  stripper drops URP/Lit — the script resolves it via `Shader.Find` at runtime,
+  with no static reference visible to the stripper — and the cubes render as
+  the magenta error material in the built `.app`. (Issue #72.) Idempotent.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Closes #72. Two macOS standalone build issues, fixed together since both surfaced during the same testing session and target the same audience.

### 1. URP/Lit shader stripped from builds (#72)

`URPBasicSceneSetup.cs` resolves URP/Lit via `Shader.Find` at runtime. Unity's build-time shader stripper has no static reference to the shader, so it's dropped from standalone builds and the cubes render as the magenta error material.

Fix: new `Samples~/URPBasicScene/Editor/URPBasicSceneShaderRegistration.cs`. Implements `IPreprocessBuildWithReport` and registers `Universal Render Pipeline/Lit` in **Project Settings > Graphics > Always Included Shaders** before any build. Idempotent (skips if already present). Also exposed as **Tools > DisplayXR > Register URP/Lit in Always Included Shaders** for users who want to register without triggering a build.

### 2. README: unsigned `.app` symlink issue + signing instructions

When the user has a runtime symlink at `~/Library/Application Support/openxr/1/active_runtime.json`, the editor finds the runtime fine, but unsigned built `.app` bundles fail with `XR_ERROR_RUNTIME_UNAVAILABLE` because macOS' file-access protections block unsigned apps from cross-app Application Support reads.

Added a "Unsigned builds and the runtime symlink" subsection under **macOS Deployment** in the main README documenting:
- Symptom (with the exact log signature)
- Workaround 1: explicit `XR_RUNTIME_JSON` (any build, signed or not)
- Workaround 2: `codesign --deep --force --sign - MyApp.app` (ad-hoc signing — no Apple Developer account needed)
- Distribution path: Developer ID + `xcrun notarytool` + `xcrun stapler`

Plus a matching one-liner row in the Troubleshooting table.

## Test plan

- [x] Built the URPBasicScene sample standalone via Unity batchmode after the fix.
- [x] Verified `[URPBasicScene] Registered 'Universal Render Pipeline/Lit'...` appears in build log.
- [x] Verified URP/Lit GUID (`933532a4fcc9baf4fa0491de14d08ed7`) appears in `ProjectSettings/GraphicsSettings.asset` `m_AlwaysIncludedShaders` after the build.
- [x] Verified the runtime no longer logs `URP/Lit shader not found` or `ArgumentNullException: shader`.
- [x] Verified OpenXR session + sim_display + stereo views still work end-to-end.
- [ ] CI: Windows + macOS native builds pass on the PR head (no native changes — should be quick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)