### PR TITLE
fix(macos): wire PointerPosition / IsLeftPressed via Mouse.current

### DIFF
--- a/Runtime/DisplayXRTransparentOverlay.cs
+++ b/Runtime/DisplayXRTransparentOverlay.cs
@@ -525,6 +525,39 @@ namespace DisplayXR
                     DisplayXRNative.displayxr_set_overlay_hit_rect(rx, ry, rw, rh);
                 }
             }
+#elif UNITY_STANDALONE_OSX
+            // (#85) Mac equivalent of the Win32 cursor/button polling — Unity
+            // uses a regular NSWindow here (no cloaked-window quirks), so
+            // Mouse.current is the right source. Drives PointerPosition /
+            // PointerDelta / IsLeftPressed for HUD routing and drag-style
+            // app code (e.g. TigerHudMouseRouter, WheelZoomVHeight). Skip in
+            // editor; gate to the active rig.
+            if (Application.isEditor || m_Camera == null)
+                return;
+            if (DisplayXRRigManager.ActiveCamera != null
+                && DisplayXRRigManager.ActiveCamera != m_Camera)
+                return;
+            #if HAS_INPUT_SYSTEM
+            {
+                var mouse = Mouse.current;
+                if (mouse != null)
+                {
+                    Vector2 raw = mouse.position.ReadValue();
+                    // Mouse.current is bottom-left origin; PointerPosition is
+                    // window-client pixels with TOP-LEFT origin (matching
+                    // Win32). Flip Y so HUD math is platform-agnostic.
+                    Vector2 pos = new Vector2(raw.x, Screen.height - raw.y);
+                    PointerDelta = m_HasPrevPointerPos
+                        ? (pos - m_PrevPointerPos)
+                        : Vector2.zero;
+                    m_PrevPointerPos = pos;
+                    m_HasPrevPointerPos = true;
+                    PointerPosition = pos;
+                    IsLeftPressed = mouse.leftButton.isPressed;
+                    IsRightPressed = mouse.rightButton.isPressed;
+                }
+            }
+            #endif
 #endif
         }
 


### PR DESCRIPTION
## Summary

\`DisplayXRTransparentOverlay\`'s \`LateUpdate\` body was entirely \`#if UNITY_STANDALONE_WIN\`, so on macOS \`PointerPosition\`, \`PointerDelta\`, and \`IsLeftPressed\` were never updated. App code that drives UI hit-testing off those properties — notably the test repo's \`TigerHudMouseRouter\` — couldn't see the cursor or button state, so HUD slider drags didn't work.

## Fix

Adds a \`UNITY_STANDALONE_OSX\` branch in \`LateUpdate\` that polls Unity's New Input System \`Mouse.current\` and updates the same public state Win32 sets:

- \`PointerPosition\` (window-client pixels, top-left origin — Y-flipped from \`Mouse.current\`'s bottom-left)
- \`PointerDelta\` (delta against previous frame)
- \`IsLeftPressed\` / \`IsRightPressed\`

Why \`Mouse.current\` is the right source on Mac (where Win32 uses a native poll): Win32 parks Unity's HWND off-screen with \`WS_EX_NOACTIVATE\` and routes input via \`RIDEV_INPUTSINK\`, which confuses Unity's new input system; native \`GetCursorPos\` + \`ScreenToClient\` is the only reliable read. macOS uses a regular \`NSWindow\` (with \`opaque=NO\` via #87) that receives normal Cocoa input events, so \`Mouse.current\` is correct as-is — no native poll required.

Active-rig gate matches Win32 so re-binding consumers on Tab cycle behaves the same.

## Test plan

- [ ] Mac built app: HUD slider drag updates the slider value
- [ ] Mac built app: HUD doesn't compete with tiger rotation when cursor moves inside the panel
- [ ] No regression on Win32 (separate \`#if UNITY_STANDALONE_WIN\` branch is untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)