### PR TITLE
feat(input): mouseLookEnabled opt-out on DisplayXRInputController

### DIFF
--- a/Runtime/DisplayXRInputController.cs
+++ b/Runtime/DisplayXRInputController.cs
@@ -25,6 +25,14 @@ namespace DisplayXR
         [Tooltip("Mouse rotation sensitivity (radians per pixel).")]
         public float rotationSensitivity = 0.005f;
 
+        [Tooltip("When false, left-mouse drag does NOT rotate the camera. " +
+                 "Useful when the app drives object-drag interactions (e.g. " +
+                 "DragRotateCube on a scene object) and wants left-drag to " +
+                 "be reserved for the app's hit-tested target, with no " +
+                 "fallback camera-look on the off-target case. WASD movement " +
+                 "and keyboard controls are unaffected.")]
+        public bool mouseLookEnabled = true;
+
         [Tooltip("Scroll wheel zoom speed (scale factor per scroll tick).")]
         public float zoomSpeed = 0.1f;
 
@@ -147,6 +155,15 @@ namespace DisplayXR
 
         private void HandleMouseRotation()
         {
+            // Opt-out: app wants left-drag reserved for its own hit-tested
+            // interactions (e.g. DragRotateCube on a target object).
+            if (!mouseLookEnabled)
+            {
+                m_Dragging = false;
+                m_DragPending = false;
+                return;
+            }
+
             // Cancel any in-progress drag if input should be ignored
             // (e.g. preview window is being moved/resized).
             // Checked every frame, not just on mouseDown, because the


### PR DESCRIPTION
## Summary

Adds a public \`mouseLookEnabled\` bool to \`DisplayXRInputController\` so apps that drive their own hit-tested left-drag interactions can opt out of the controller's default left-mouse-drag → camera rotation. WASD, scroll zoom, keyboard controls unaffected.

## Why

With the Mac overlay hit-test port (#95 / v1.5.7), apps wiring up \`DragRotateCube\` on a scene target hit a double-rotation bug:

- Left-drag **on target** → both \`DragRotateCube\` (target rotates) AND \`DisplayXRInputController\` (camera rotates) fire → compounded ~2x rotation rate
- Left-drag **off target** → \`DragRotateCube\` correctly doesn't fire, but the camera still rotates via \`DisplayXRInputController\` → target appears to rotate even though click missed

The fix gates the controller's left-drag at a known opt-out point. The test repo's \`TransparentAutoSetup\` sets \`mouseLookEnabled = false\` on each rig camera (parallel commit in the test repo).

## Default behavior unchanged

\`mouseLookEnabled = true\` is the default → all existing apps keep the camera-look behavior.

## Test plan

- [x] Plugin builds clean
- [ ] Test repo with \`mouseLookEnabled = false\`: left-drag on tiger rotates ONLY the tiger; left-drag off tiger does nothing
- [ ] Test repo with default (true): camera rotates on left-drag as before
- [ ] Win32 unaffected (same code path, no platform-specific changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)