### PR TITLE
ext: XR_EXT_display_info v13 ABI sync

### DIFF
--- a/native~/displayxr_extensions.h
+++ b/native~/displayxr_extensions.h
@@ -55,6 +55,14 @@ typedef struct XrDisplayRenderingModeInfoEXT {
     uint32_t tileRows;
     uint32_t viewWidthPixels;
     uint32_t viewHeightPixels;
+    // v13 (DisplayXR runtime v1.4.0+): isActive marks the current mode for
+    // this session; isRequestable is false for non-controller workspace
+    // clients (runtime drops xrRequestDisplayRenderingModeEXT). Plugin
+    // doesn't currently consume them, but the struct sizeof must match
+    // the runtime's so xrEnumerateDisplayRenderingModesEXT writes modes[i]
+    // at the right stride. See DisplayXR/displayxr-runtime#234.
+    XrBool32 isActive;
+    XrBool32 isRequestable;
 } XrDisplayRenderingModeInfoEXT;
 
 typedef XrResult(XRAPI_PTR *PFN_xrEnumerateDisplayRenderingModesEXT)(


### PR DESCRIPTION
## Summary

Closes #106.

Append `isActive` + `isRequestable` (both `XrBool32`) to `XrDisplayRenderingModeInfoEXT` in `native~/displayxr_extensions.h` to match the runtime's v13 layout (DisplayXR/displayxr-runtime#234).

Without this sync, the plugin's `modes[i+1]` reads from `xrEnumerateDisplayRenderingModesEXT` are misaligned against where the runtime wrote them.

Plugin doesn't yet consume the new fields — minimal ABI-only fix. Future PR can wire them into the C# layer if useful (e.g., DisplayXRController exposing "mode locked" state to game code).

## Test plan

- [ ] CI build green (rebuilds native DLL with new header).
- [ ] Sample scene against runtime v13 enumerates modes correctly (no shifted reads on `modes[1+]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)