### PR TITLE
Restore Unity 6.0 compat in DisplayXRPreviewSession (#109)

### DIFF
--- a/Editor/DisplayXRPreviewSession.cs
+++ b/Editor/DisplayXRPreviewSession.cs
@@ -669,7 +669,7 @@ namespace DisplayXR.Editor
 
         public static CameraEntry[] DiscoverCameras()
         {
-            var cameras = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsInactive.Exclude);
+            var cameras = UnityEngine.Object.FindObjectsByType<Camera>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
             var entries = new List<CameraEntry>();
 
             foreach (var cam in cameras)
@@ -716,7 +716,7 @@ namespace DisplayXR.Editor
             s_SelectedSourceCamera = cam;
             if (cam != null)
             {
-                SessionState.SetString(kSelectedCameraIDKey, cam.GetEntityId().ToString());
+                SessionState.SetString(kSelectedCameraIDKey, cam.GetInstanceID().ToString());
                 SessionState.SetString(kSelectedCameraNameKey, cam.gameObject.name);
             }
             else
@@ -734,13 +734,11 @@ namespace DisplayXR.Editor
 
         public static void RestoreSelection()
         {
-            // 1. Try EntityId (precise, survives assembly reload in Edit Mode)
+            // 1. Try InstanceID (precise, survives assembly reload in Edit Mode)
             string savedID = SessionState.GetString(kSelectedCameraIDKey, "");
             if (!string.IsNullOrEmpty(savedID) && int.TryParse(savedID, out int id) && id != 0)
             {
-#pragma warning disable CS0618 // EntityId int cast — no non-deprecated constructor available yet
-                var obj = EditorUtility.EntityIdToObject((EntityId)id) as Camera;
-#pragma warning restore CS0618
+                var obj = EditorUtility.InstanceIDToObject(id) as Camera;
                 if (obj != null)
                 {
                     s_SelectedSourceCamera = obj;
@@ -749,7 +747,7 @@ namespace DisplayXR.Editor
                 }
             }
 
-            // 2. Try camera name (survives Play Mode domain reload where EntityId is invalidated)
+            // 2. Try camera name (survives Play Mode domain reload where InstanceID is invalidated)
             string savedName = SessionState.GetString(kSelectedCameraNameKey, "");
             if (!string.IsNullOrEmpty(savedName))
             {
@@ -785,7 +783,7 @@ namespace DisplayXR.Editor
 
             if (s_SelectedSourceCamera != null)
             {
-                SessionState.SetString(kSelectedCameraIDKey, s_SelectedSourceCamera.GetEntityId().ToString());
+                SessionState.SetString(kSelectedCameraIDKey, s_SelectedSourceCamera.GetInstanceID().ToString());
                 SessionState.SetString(kSelectedCameraNameKey, s_SelectedSourceCamera.gameObject.name);
                 ApplyCameraSelection();
             }

--- a/docs~/architecture/preview-session.md
+++ b/docs~/architecture/preview-session.md
@@ -46,7 +46,7 @@ When the user presses Play with the preview running:
 1. **ExitingEditMode:** Disable Unity's XR loader (`TryRemoveLoader`), save `PlayModeStartedKey = IsRunning`
 2. **Domain reload:** `OnBeforeAssemblyReload` → `Stop()` (statics wiped, native session stopped)
 3. **EnteredPlayMode:** Read `PlayModeStartedKey` from SessionState → `Start()` → `RestoreSelection()`
-4. **Camera restore:** Try EntityId (fails after domain reload) → try camera name → fallback to first rig
+4. **Camera restore:** Try InstanceID (fails after domain reload) → try camera name → fallback to first rig
 5. **ExitingPlayMode:** `Stop()`, clear flag
 6. **EnteredEditMode:** Re-enable XR loader (`TryAddLoader`), focus Scene View
 


### PR DESCRIPTION
## Summary

- Replace three Unity 6.1+ APIs in `Editor/DisplayXRPreviewSession.cs` (`GetEntityId`, `EntityIdToObject`, single-arg `FindObjectsByType<T>(FindObjectsInactive)`) with the cross-version-safe `GetInstanceID`/`InstanceIDToObject`/two-arg `FindObjectsByType` equivalents
- Update `docs~/architecture/preview-session.md` reference from "EntityId" to "InstanceID"

Fixes #109 — partner reported 5 compile errors on Unity `6000.0.23f1` after opening the source of `displayxr-unity-test-transparent` v1.7.0. Pre-built Player binary was unaffected; only editor source compile failed.

The `Entity*` usages came in via #43 (`78c3298`); the `FindObjectsByType` regression undid #66 via #69 (`abde618`). Replacement APIs all exist since Unity 2022.2 (the package's stated floor) and remain functional in 6.1 — deprecation warnings on dev machines are inert.

## Test plan

- [ ] CI green on PR head (Windows x64 DLL + macOS Universal bundle build)
- [ ] Open `displayxr-unity-test-transparent` (or any test repo) in Unity 6000.0.23f1 — no compile errors in `Library/PackageCache/com.displayxr.unity/Editor/`
- [ ] Open same project in Unity 6.1+ — still compiles, no new errors (deprecation warnings on `GetInstanceID`/`InstanceIDToObject` are expected and inert)
- [ ] Standalone preview window: select a camera, restart preview, verify selection restores (exercises the `InstanceIDToObject` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)