### PR TITLE
Gizmo follow-ups: untracked-valid poses, Kooima frustum geometry, visible glyphs (#111)

### DIFF
--- a/Runtime/DisplayXRCamera.cs
+++ b/Runtime/DisplayXRCamera.cs
@@ -265,16 +265,16 @@ namespace DisplayXR
             Color eyeColor = isLive ? DisplayXRGizmoHelpers.EyeGlyphLive
                                     : DisplayXRGizmoHelpers.EyeGlyphNominal;
 
-            float farDist = 5f * Mathf.Max(w, h);
-            if (cam != null) farDist = Mathf.Min(farDist, cam.farClipPlane);
+            float nearDist = cam != null ? cam.nearClipPlane : 0.3f;
+            float farDist = cam != null ? cam.farClipPlane : 1000f;
 
             for (int i = 0; i < count; i++)
             {
                 Vector3 eye = m_GizmoEyes[i];
                 DisplayXRGizmoHelpers.DrawAsymmetricFrustum(
-                    eye, cBL, cBR, cTR, cTL, farDist, frustumColor);
+                    eye, cBL, cBR, cTR, cTL, nearDist, farDist, frustumColor);
                 DisplayXRGizmoHelpers.DrawEyeGlyph(
-                    eye, transform.rotation, 0.03f, eyeColor);
+                    eye, transform.rotation, 0.05f, eyeColor);
             }
         }
 #endif

--- a/Runtime/DisplayXRCamera.cs
+++ b/Runtime/DisplayXRCamera.cs
@@ -274,7 +274,7 @@ namespace DisplayXR
                 DisplayXRGizmoHelpers.DrawAsymmetricFrustum(
                     eye, cBL, cBR, cTR, cTL, farDist, frustumColor);
                 DisplayXRGizmoHelpers.DrawEyeGlyph(
-                    eye, transform.rotation, 0.015f, eyeColor);
+                    eye, transform.rotation, 0.03f, eyeColor);
             }
         }
 #endif

--- a/Runtime/DisplayXRDisplay.cs
+++ b/Runtime/DisplayXRDisplay.cs
@@ -259,7 +259,7 @@ namespace DisplayXR
                 DisplayXRGizmoHelpers.DrawAsymmetricFrustum(
                     eye, cBL, cBR, cTR, cTL, farDist, frustumColor);
                 DisplayXRGizmoHelpers.DrawEyeGlyph(
-                    eye, transform.rotation, 0.015f, eyeColor);
+                    eye, transform.rotation, 0.03f, eyeColor);
             }
         }
 #endif

--- a/Runtime/DisplayXRDisplay.cs
+++ b/Runtime/DisplayXRDisplay.cs
@@ -247,19 +247,19 @@ namespace DisplayXR
             Color eyeColor = isLive ? DisplayXRGizmoHelpers.EyeGlyphLive
                                     : DisplayXRGizmoHelpers.EyeGlyphNominal;
 
-            // Far distance for the truncated pyramid. Camera.farClipPlane
-            // defaults to 1000 m which fills the entire scene — clamp to a
-            // few display-widths so the gizmo stays legible.
-            float farDist = 5f * Mathf.Max(w, h);
-            if (cam != null) farDist = Mathf.Min(farDist, cam.farClipPlane);
+            // Near + far come straight from the camera. The frustum helper
+            // clamps far internally so we don't fill the whole scene at
+            // farClipPlane = 1000 m.
+            float nearDist = cam != null ? cam.nearClipPlane : 0.3f;
+            float farDist = cam != null ? cam.farClipPlane : 1000f;
 
             for (int i = 0; i < count; i++)
             {
                 Vector3 eye = m_GizmoEyes[i];
                 DisplayXRGizmoHelpers.DrawAsymmetricFrustum(
-                    eye, cBL, cBR, cTR, cTL, farDist, frustumColor);
+                    eye, cBL, cBR, cTR, cTL, nearDist, farDist, frustumColor);
                 DisplayXRGizmoHelpers.DrawEyeGlyph(
-                    eye, transform.rotation, 0.03f, eyeColor);
+                    eye, transform.rotation, 0.05f, eyeColor);
             }
         }
 #endif

--- a/Runtime/DisplayXRGizmoHelpers.cs
+++ b/Runtime/DisplayXRGizmoHelpers.cs
@@ -390,7 +390,11 @@ namespace DisplayXR
             Gizmos.color = color;
             var saved = Gizmos.matrix;
             Gizmos.matrix = Matrix4x4.TRS(pos, orient, Vector3.one);
-            Gizmos.DrawWireCube(Vector3.zero, Vector3.one * size);
+            // Filled sphere — the most readable marker at typical Scene-view
+            // zoom levels. The earlier wire-cube + forward-line combo at 1.5 cm
+            // was effectively invisible inside the converging frustum lines.
+            Gizmos.DrawSphere(Vector3.zero, size * 0.5f);
+            // Forward stub keeps orientation visible.
             Gizmos.DrawLine(Vector3.zero, new Vector3(0, 0, size * 2.0f));
             Gizmos.matrix = saved;
         }

--- a/Runtime/DisplayXRGizmoHelpers.cs
+++ b/Runtime/DisplayXRGizmoHelpers.cs
@@ -351,37 +351,81 @@ namespace DisplayXR
         // -----------------------------------------------------------------
 
         /// <summary>
-        /// Asymmetric (Kooima) frustum: eye → 4 display corners, plus a far
-        /// quad along each eye→corner ray (extrapolated past the display
-        /// plane). farDistanceFromEye is measured from the eye.
+        /// Asymmetric (Kooima) frustum: per-eye truncated pyramid bounded by
+        /// the near, display, and far planes. The near and far planes are
+        /// parallel to the display plane (i.e. perpendicular to the display
+        /// normal) — NOT perpendicular to each eye-corner ray. Drawing them
+        /// along the rays would tilt them, which is incorrect for off-axis
+        /// projection.
+        ///
+        /// nearDist and farDist are perpendicular distances from the eye to
+        /// the near/far planes, in display-normal direction (i.e. world
+        /// meters along the display's forward axis). farDist is clamped to
+        /// keep the gizmo legible — the actual rendered far plane may sit
+        /// further out.
         /// </summary>
         public static void DrawAsymmetricFrustum(
             Vector3 eye,
             Vector3 cBL, Vector3 cBR, Vector3 cTR, Vector3 cTL,
-            float farDistanceFromEye, Color color)
+            float nearDist, float farDist,
+            Color color)
         {
-            Gizmos.color = color;
-            Gizmos.DrawLine(eye, cBL);
-            Gizmos.DrawLine(eye, cBR);
-            Gizmos.DrawLine(eye, cTR);
-            Gizmos.DrawLine(eye, cTL);
+            // Display plane center + normal. Normal flipped to point toward
+            // the eye if needed, so signedDist is positive.
+            Vector3 planeCenter = (cBL + cBR + cTR + cTL) * 0.25f;
+            Vector3 planeNormal = Vector3.Cross(cBR - cBL, cTL - cBL).normalized;
+            float signedDist = Vector3.Dot(eye - planeCenter, planeNormal);
+            if (signedDist < 0f)
+            {
+                planeNormal = -planeNormal;
+                signedDist = -signedDist;
+            }
+            float dDisp = signedDist;
+            if (dDisp < 1e-4f) return; // eye coplanar with display, degenerate
 
-            Vector3 fBL = ExtrapolateRay(eye, cBL, farDistanceFromEye);
-            Vector3 fBR = ExtrapolateRay(eye, cBR, farDistanceFromEye);
-            Vector3 fTR = ExtrapolateRay(eye, cTR, farDistanceFromEye);
-            Vector3 fTL = ExtrapolateRay(eye, cTL, farDistanceFromEye);
+            // Clamp so the frustum stays inside a reasonable visual envelope.
+            // Near stays in front of the display (between eye and display);
+            // far sits 1.5-3× display distance past the display.
+            float nSafe = Mathf.Clamp(nearDist, 0.001f, dDisp * 0.5f);
+            float fSafe = Mathf.Clamp(farDist, dDisp * 1.5f, dDisp * 3f);
+
+            float tN = nSafe / dDisp;
+            float tF = fSafe / dDisp;
+
+            Vector3 nBL = eye + tN * (cBL - eye);
+            Vector3 nBR = eye + tN * (cBR - eye);
+            Vector3 nTR = eye + tN * (cTR - eye);
+            Vector3 nTL = eye + tN * (cTL - eye);
+            Vector3 fBL = eye + tF * (cBL - eye);
+            Vector3 fBR = eye + tF * (cBR - eye);
+            Vector3 fTR = eye + tF * (cTR - eye);
+            Vector3 fTL = eye + tF * (cTL - eye);
+
+            Gizmos.color = color;
+
+            // Apex edges: eye → 4 near corners.
+            Gizmos.DrawLine(eye, nBL);
+            Gizmos.DrawLine(eye, nBR);
+            Gizmos.DrawLine(eye, nTR);
+            Gizmos.DrawLine(eye, nTL);
+
+            // Near plane rectangle.
+            Gizmos.DrawLine(nBL, nBR);
+            Gizmos.DrawLine(nBR, nTR);
+            Gizmos.DrawLine(nTR, nTL);
+            Gizmos.DrawLine(nTL, nBL);
+
+            // Connecting edges near → far (pass through the display plane).
+            Gizmos.DrawLine(nBL, fBL);
+            Gizmos.DrawLine(nBR, fBR);
+            Gizmos.DrawLine(nTR, fTR);
+            Gizmos.DrawLine(nTL, fTL);
+
+            // Far plane rectangle.
             Gizmos.DrawLine(fBL, fBR);
             Gizmos.DrawLine(fBR, fTR);
             Gizmos.DrawLine(fTR, fTL);
             Gizmos.DrawLine(fTL, fBL);
-        }
-
-        static Vector3 ExtrapolateRay(Vector3 origin, Vector3 through, float distance)
-        {
-            Vector3 dir = through - origin;
-            float len = dir.magnitude;
-            if (len < 1e-5f) return through;
-            return origin + dir * (distance / len);
         }
 
         public static void DrawEyeGlyph(

--- a/Runtime/DisplayXRGizmoHelpers.cs
+++ b/Runtime/DisplayXRGizmoHelpers.cs
@@ -125,7 +125,13 @@ namespace DisplayXR
         /// −Z forward). Standalone preview path returns up to N; Unity
         /// hook chain (Play Mode) returns 2. Returns the number written;
         /// 0 if no live data is available or the data is degenerate
-        /// (all-zero, or L==R with N==2 — head-center-only sessions).
+        /// (all-zero, or L==R / all-same — head-center-only sessions).
+        ///
+        /// Does NOT gate on the tracked bit. sim_display is marked as
+        /// non-tracking but returns valid eye poses (runtime commit
+        /// e0cefdce0); gating on tracked would discard every gizmo update
+        /// in editor preview against sim_display. The degenerate-eye-set
+        /// check below catches all-zero / all-same fallbacks instead.
         /// </summary>
         public static int TryGetLiveRawEyes(Vector3[] eyesOut)
         {
@@ -138,8 +144,8 @@ namespace DisplayXR
             try
             {
                 DisplayXRNative.displayxr_standalone_get_n_eye_positions(
-                    s_NEyeBuf, (uint)cap, out uint outCount, out int outTracked);
-                if (outTracked != 0 && outCount > 0)
+                    s_NEyeBuf, (uint)cap, out uint outCount, out int _);
+                if (outCount > 0)
                 {
                     int n = (int)outCount;
                     for (int i = 0; i < n; i++)
@@ -156,6 +162,8 @@ namespace DisplayXR
             catch (System.EntryPointNotFoundException) { }
 
             // 2) Unity hook chain (Play Mode XR loader): 2 eyes only.
+            // Keep the tracked gate here — XR sessions can legitimately
+            // be in pre-tracked state and we don't want to draw stale data.
             if (cap >= 2)
             {
                 int tracked = 0;


### PR DESCRIPTION
## Summary

Three follow-ups to PR #112 (issue #111), verified end-to-end against displayxr-runtime `28518f0a9 fix(#246)` + sim_display Quad mode:

1. **Drop \`outTracked != 0\` gate on \`displayxr_standalone_get_n_eye_positions\`** (\`2a4f172\`). sim_display is intentionally non-tracking but always returns valid eye poses (runtime commit \`e0cefdce0\`), so the gizmo was discarding every per-view update against it. Now relies on the degenerate-eye-set check (all-zero / all-same) to filter, which is the correct behavior per the DP view-pose contract. Unity-hook path (Play Mode) keeps the tracked gate.
2. **Make eye glyphs visible** (\`4ee415d\` + \`fd82311\`). Replaced the 1.5 cm wire-cube + forward-line glyph with a 5 cm filled yellow sphere (+ forward stub for orientation). The wire cube at 1.5 cm was effectively invisible inside the converging frustum lines.
3. **Fix Kooima frustum geometry** (\`fd82311\`). Old code extrapolated each eye→display-corner ray to a fixed distance from the eye, producing far quads that tilted with off-axis direction. New code intersects with planes parallel to the display plane (perpendicular to its normal) — correct Kooima behavior. Adds the near plane (was missing). Per-frustum: 4 apex edges + near rect + 4 connecting edges through the display plane + far rect.

## Visual result with runtime #246 fix landed and Quad mode active

- 4 magenta asymmetric frustums (one per tile) sharing the display rect, with near + far planes correctly parallel to the display.
- 4 yellow filled-sphere eye glyphs at the per-tile viewer positions synthesized from \`view_eye_offsets\`.
- Light-blue display volume (display-centric) / orange convergence volume (camera-centric) unchanged.

## Test plan

- [x] CI green on both platforms.
- [x] Verified in \`displayxr-unity-test\` (macOS, runtime \`v1.3.3-8\` rebuilt with \`fix(#246)\` commit 28518f0a9):
  - Quad mode in editor preview: 4 distinct frustums + 4 distinct eye spheres ✅
  - Near/far quads parallel to display plane (not tilted) ✅
  - Eye glyphs clearly visible at typical Scene-view zoom ✅
  - Standard 3D mode: 2 frustums, regression-free ✅

## Memory note

Saved \`reference_dp_view_pose_contract.md\` to project memory: future sessions will avoid the same \`POSITION_TRACKED\` gating bug pattern.

## Related

- Closes the verification follow-up for #111.
- Runtime fix it depends on: DisplayXR/displayxr-runtime#246 + commit 28518f0a9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)