### PR TITLE
Edit Mode preview: gizmo updates real-time during drag

### DIFF
--- a/Runtime/DisplayXRGizmoHelpers.cs
+++ b/Runtime/DisplayXRGizmoHelpers.cs
@@ -542,16 +542,24 @@ namespace DisplayXR
         public static readonly Color EyeGlyphNominal = new Color(0.9f, 0.85f, 0.3f, 0.7f);
     }
 
-    // Forces Scene-view repaints when the SA preview window's canvas rect
-    // changes, so the gizmo (virtual display rect + frustum + eye glyphs)
-    // tracks window drag/resize in real time. Without this, Scene view
-    // only repaints on user interaction → gizmo lags behind window edits.
-    // Cheap: polls a single native getter, no repaint when canvas is stable.
+    // Forces Scene View to repaint each editor frame while the SA preview
+    // is running in Edit Mode, so the gizmo (virtual display rect + frustum
+    // + eye glyphs) tracks window drag/resize in real time.
+    //
+    // Why: without this, Scene View only repaints on explicit invalidation
+    // or user interaction. During an SA preview drag/resize, the WndProc's
+    // capture-based SC_MOVE/SC_SIZE intercept floods Unity's main thread
+    // with WM_MOUSEMOVE messages, starving Scene View's repaint cycle —
+    // gizmo only catches up when the drag releases.
+    //
+    // Play Mode is intentionally excluded: Unity's play frame loop already
+    // drives continuous Scene View repaints, so the gizmo updates real-time
+    // there for free. Adding our own RepaintAll on top of that just adds
+    // contention with the teardown path (avoids re-entrant OnDrawGizmos
+    // triggering native reads while the SA session is mid-destroy).
     [UnityEditor.InitializeOnLoad]
     internal static class DisplayXRGizmoRepainter
     {
-        static DisplayXRGizmoHelpers.CanvasRect s_LastCanvas;
-
         static DisplayXRGizmoRepainter()
         {
             UnityEditor.EditorApplication.update += Tick;
@@ -559,11 +567,8 @@ namespace DisplayXR
 
         static void Tick()
         {
-            var c = DisplayXRGizmoHelpers.TryGetCanvasRect();
-            if (!c.isValid) return;
-            if (c.x == s_LastCanvas.x && c.y == s_LastCanvas.y &&
-                c.w == s_LastCanvas.w && c.h == s_LastCanvas.h) return;
-            s_LastCanvas = c;
+            if (Application.isPlaying) return;
+            if (!DisplayXRGizmoHelpers.IsSessionActive()) return;
             UnityEditor.SceneView.RepaintAll();
         }
     }


### PR DESCRIPTION
## Summary

Follow-up fix to v1.8.0's window-relative gizmo work. The `DisplayXRGizmoRepainter` only triggered `SceneView.RepaintAll()` when it detected a canvas-rect change, which worked in Play Mode (Unity's frame loop drives continuous repaints anyway) but lagged in **Edit Mode + Preview** during drag/resize — the WndProc's SC_MOVE/SC_SIZE intercept floods the main thread with `WM_MOUSEMOVE`, starving the change-detection poll. Gizmo only caught up when the drag released.

Switches the repainter to unconditional `RepaintAll` every editor frame while the SA preview is running in Edit Mode. Explicitly skips Play Mode to avoid contention with Play Mode's teardown path.

## Test plan

- [ ] Open `displayxr-unity-test` → Window > DisplayXR > Preview Window → Start.
- [ ] Drag the preview window across the panel → Scene View cyan rect + frustum apex track in real time (previously laggy).
- [ ] Resize via border → same, real-time tracking during the resize.
- [ ] Press Play → still real-time (Play Mode path unchanged).
- [ ] CI: both Windows + macOS pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)