### PR TITLE
Fix(preview): MSAA atlas RT so silhouettes get fractional alpha

### DIFF
--- a/Editor/DisplayXRPreviewSession.cs
+++ b/Editor/DisplayXRPreviewSession.cs
@@ -60,6 +60,15 @@ namespace DisplayXR.Editor
 
         // Rendering rig
         private static RenderTexture s_AtlasRT;
+        // MSAA intermediate: eye cameras render here, then Blit-resolves into
+        // s_AtlasRT so all downstream consumers (bridge copy, screenshot,
+        // GameView overlay, native swapchain submit) keep the single-sampled
+        // contract. Null when QualitySettings.antiAliasing == 0; in that case
+        // cameras render directly to s_AtlasRT with no MSAA.
+        // Without this, silhouette edges land in s_AtlasRT with binary alpha
+        // (alpha=0 outside, alpha=1 inside, no fractional coverage), which
+        // shows up as visible aliasing in alpha-native transparent overlays.
+        private static RenderTexture s_AtlasMsaaRT;
         private static Texture2D s_AtlasBridgeTex; // Windows D3D12: cross-device bridge
         private static Camera[] s_EyeCams;
         private static GameObject s_RigRoot;
@@ -418,7 +427,10 @@ namespace DisplayXR.Editor
             {
                 s_FrameCount++;
 
-                // Render each eye into its tile within the atlas
+                // Render each eye into its tile within the atlas. Target the
+                // MSAA intermediate when available so silhouette edges get
+                // fractional alpha; resolved into s_AtlasRT below.
+                RenderTexture renderTarget = s_AtlasMsaaRT != null ? s_AtlasMsaaRT : s_AtlasRT;
                 for (int eye = 0; eye < nViews && eye < s_EyeCams.Length; eye++)
                 {
                     if (s_EyeCams[eye] == null) continue;
@@ -430,10 +442,16 @@ namespace DisplayXR.Editor
                     System.Array.Copy(viewMats, eye * 16, eyeView, 0, 16);
                     System.Array.Copy(projMats, eye * 16, eyeProj, 0, 16);
 
-                    RenderEyeToAtlas(s_EyeCams[eye], s_AtlasRT, eyeView, eyeProj,
+                    RenderEyeToAtlas(s_EyeCams[eye], renderTarget, eyeView, eyeProj,
                         (int)(tileX * s_ViewWidth), (int)(tileY * s_ViewHeight),
                         (int)s_ViewWidth, (int)s_ViewHeight);
                 }
+
+                // Resolve MSAA → single-sampled atlas. Graphics.Blit on an
+                // MSAA source performs the hardware resolve (averages all
+                // channels including alpha) before copying.
+                if (s_AtlasMsaaRT != null)
+                    Graphics.Blit(s_AtlasMsaaRT, s_AtlasRT);
 
                 // Atlas is fully rendered. Service screenshot capture / flash
                 // overlay before the bridge copy so any flash is visible on the
@@ -484,10 +502,26 @@ namespace DisplayXR.Editor
             Debug.Log($"[DisplayXR-SA] Creating atlas render rig: {s_AtlasWidth}x{s_AtlasHeight} " +
                 $"({s_ViewCount} views, {s_TileColumns}x{s_TileRows} tiles, {s_ViewWidth}x{s_ViewHeight} per view)");
 
-            // Create single atlas RenderTexture
+            // Create single atlas RenderTexture (single-sampled — submission target).
             s_AtlasRT = new RenderTexture((int)s_AtlasWidth, (int)s_AtlasHeight, 24, RenderTextureFormat.ARGB32);
             s_AtlasRT.name = "DisplayXR_SA_Atlas";
             s_AtlasRT.Create();
+
+            // MSAA intermediate for camera rasterization. Cameras rendering
+            // into a RenderTexture inherit its MSAA setting, NOT
+            // QualitySettings.antiAliasing or Camera.allowMSAA. Without an
+            // MSAA target here, silhouettes carry binary alpha — visible as
+            // aliasing in alpha-native transparent overlays.
+            int msaa = QualitySettings.antiAliasing > 0 ? QualitySettings.antiAliasing : 1;
+            if (msaa > 1)
+            {
+                var msaaDesc = new RenderTextureDescriptor(
+                    (int)s_AtlasWidth, (int)s_AtlasHeight, RenderTextureFormat.ARGB32, 24);
+                msaaDesc.msaaSamples = msaa;
+                s_AtlasMsaaRT = new RenderTexture(msaaDesc);
+                s_AtlasMsaaRT.name = "DisplayXR_SA_AtlasMSAA";
+                s_AtlasMsaaRT.Create();
+            }
 
             // Create hidden camera rig with N eye cameras
             s_RigRoot = new GameObject("DisplayXR_SA_Rig");
@@ -521,6 +555,8 @@ namespace DisplayXR.Editor
 
             if (s_AtlasRT != null) { s_AtlasRT.Release(); UnityEngine.Object.DestroyImmediate(s_AtlasRT); }
             s_AtlasRT = null;
+            if (s_AtlasMsaaRT != null) { s_AtlasMsaaRT.Release(); UnityEngine.Object.DestroyImmediate(s_AtlasMsaaRT); }
+            s_AtlasMsaaRT = null;
         }
 
         private static void CreateAtlasBridge()


### PR DESCRIPTION
## Summary
- Standalone preview created the eye-camera atlas via the no-MSAA `RenderTexture` constructor (line 488).
- Cameras pointed at a non-MSAA `targetTexture` rasterize without MSAA regardless of `QualitySettings.antiAliasing` or `Camera.allowMSAA` — the RT's setting wins.
- Net effect: silhouette edges in the atlas land with binary alpha (0/1, no fractional coverage), visible as hard aliasing in alpha-native transparent overlays. Textured assets (Mixamo tiger fur) masked it; flat-shaded characters expose it.

## Fix
- Add an MSAA intermediate, `s_AtlasMsaaRT`, sized like `s_AtlasRT` and created with `msaaSamples = QualitySettings.antiAliasing` when `antiAliasing > 0`.
- Eye cameras now target the MSAA intermediate. After all eyes draw, `Graphics.Blit` resolves into the existing single-sampled `s_AtlasRT` (hardware MSAA resolve, alpha-aware).
- Downstream consumers (D3D12 bridge copy, screenshot capture, `DisplayXRGameViewOverlay`, native swapchain submit) keep the single-sampled contract — no changes outside `CreateRenderRig` / `FrameTick` / `DestroyRenderRig`.
- When `antiAliasing == 0`, the intermediate stays null and the original zero-overhead path runs.

Editor-only — no native rebuild.

## Test plan
- [x] Locally verified in the test-transparent project (proprietary flat-shaded character): silhouette went from hard-binary to soft fractional alpha after the patch, no change to non-silhouette pixels.
- [ ] Verify with `QualitySettings.antiAliasing = 0` — intermediate should not be created, no regression on the zero-MSAA path.
- [ ] Verify in `displayxr-unity-test` (Mixamo tiger) — should look the same or slightly softer; no regression.
- [ ] Verify the screenshot capture (`DisplayXRScreenshot`) still produces a valid image — it reads from `s_AtlasRT` post-resolve.

## Follow-up (not in this PR)
- Build path (Unity OpenXR loader → eye texture) shows the same binary-alpha symptom. Different code path entirely (Unity controls eye RT creation, not the plugin). Tracking as a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)