### PR TITLE
Rig-level post-process FXAA for the XR eye RT (#121)

### DIFF
--- a/Editor/DisplayXRCameraEditor.cs
+++ b/Editor/DisplayXRCameraEditor.cs
@@ -13,6 +13,7 @@ namespace DisplayXR.Editor
         private SerializedProperty m_IpdFactor;
         private SerializedProperty m_ParallaxFactor;
         private SerializedProperty m_InvConvergenceDistance;
+        private SerializedProperty m_PostProcessAntiAliasing;
         private SerializedProperty m_LogEyeTracking;
 
         void OnEnable()
@@ -21,6 +22,7 @@ namespace DisplayXR.Editor
             m_IpdFactor = serializedObject.FindProperty("ipdFactor");
             m_ParallaxFactor = serializedObject.FindProperty("parallaxFactor");
             m_InvConvergenceDistance = serializedObject.FindProperty("invConvergenceDistance");
+            m_PostProcessAntiAliasing = serializedObject.FindProperty("postProcessAntiAliasing");
             m_LogEyeTracking = serializedObject.FindProperty("logEyeTracking");
         }
 
@@ -64,6 +66,13 @@ namespace DisplayXR.Editor
                 EditorGUILayout.LabelField(" ", "(\u221E)");
             }
             EditorGUI.indentLevel--;
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Rendering", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(m_PostProcessAntiAliasing,
+                new GUIContent("Post-Process AA (FXAA)",
+                    "Unity drops MSAA on the XR eye RT, so silhouettes alias. " +
+                    "FXAA restores soft edges post-resolve. Disable if not needed."));
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(m_LogEyeTracking);

--- a/Editor/DisplayXRDisplayEditor.cs
+++ b/Editor/DisplayXRDisplayEditor.cs
@@ -14,6 +14,7 @@ namespace DisplayXR.Editor
         private SerializedProperty m_ParallaxFactor;
         private SerializedProperty m_PerspectiveFactor;
         private SerializedProperty m_VirtualDisplayHeight;
+        private SerializedProperty m_PostProcessAntiAliasing;
         private SerializedProperty m_LogEyeTracking;
 
         void OnEnable()
@@ -23,6 +24,7 @@ namespace DisplayXR.Editor
             m_ParallaxFactor = serializedObject.FindProperty("parallaxFactor");
             m_PerspectiveFactor = serializedObject.FindProperty("perspectiveFactor");
             m_VirtualDisplayHeight = serializedObject.FindProperty("virtualDisplayHeight");
+            m_PostProcessAntiAliasing = serializedObject.FindProperty("postProcessAntiAliasing");
             m_LogEyeTracking = serializedObject.FindProperty("logEyeTracking");
         }
 
@@ -71,6 +73,13 @@ namespace DisplayXR.Editor
                     EditorGUI.indentLevel--;
                 }
             }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Rendering", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(m_PostProcessAntiAliasing,
+                new GUIContent("Post-Process AA (FXAA)",
+                    "Unity drops MSAA on the XR eye RT, so silhouettes alias. " +
+                    "FXAA restores soft edges post-resolve. Disable if not needed."));
 
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(m_LogEyeTracking);

--- a/Runtime/DisplayXRCamera.cs
+++ b/Runtime/DisplayXRCamera.cs
@@ -40,6 +40,15 @@ namespace DisplayXR
                  "projection has no finite convergence point).")]
         public bool foregroundOnlyClip = false;
 
+        [Header("Rendering")]
+
+        [Tooltip("Post-process FXAA on the eye render target. Unity drops MSAA on the XR " +
+                 "eye RT (submits sampleCount=1 and its resolve loses fractional alpha), so " +
+                 "silhouettes alias — most visibly in alpha-native transparent overlays. " +
+                 "FXAA restores soft edges post-resolve where MSAA/supersampling can't. " +
+                 "Disable if you don't need it.")]
+        public bool postProcessAntiAliasing = true;
+
         [Header("Debug")]
 
         [Tooltip("Show eye tracking status in the console.")]
@@ -48,6 +57,7 @@ namespace DisplayXR
         private DisplayXRFeature m_Feature;
         private float m_CachedCameraFov;
         private Camera m_Camera;
+        private DisplayXRPostAA m_PostAA;
         // True when running under URP/HDRP. BiRP fires Camera.onPreRender; SRP doesn't,
         // so we route through RenderPipelineManager.beginCameraRendering instead.
         private bool m_UsingSRP;
@@ -77,6 +87,11 @@ namespace DisplayXR
             else
                 Camera.onPreRender += OnCameraPreRender;
             DisplayXRRigManager.Register(m_Camera);
+
+            // Post-process AA: Unity drops MSAA on the XR eye RT, so attach a
+            // (hidden, rig-managed) FXAA pass and mirror the toggle onto it.
+            m_PostAA = DisplayXRPostAA.Ensure(gameObject);
+            m_PostAA.enabled = postProcessAntiAliasing;
         }
 
         void OnDisable()
@@ -123,6 +138,10 @@ namespace DisplayXR
 
         void LateUpdate()
         {
+            // Keep the post-process AA pass tracking the toggle (inspector or
+            // runtime). Before the active-rig gate so every rig tracks its own flag.
+            if (m_PostAA != null) m_PostAA.enabled = postProcessAntiAliasing;
+
             // Only the active rig pushes tunables (prevents multi-rig conflicts)
             var active = DisplayXRRigManager.ActiveCamera;
             if (active != null && active != m_Camera) return;

--- a/Runtime/DisplayXRDisplay.cs
+++ b/Runtime/DisplayXRDisplay.cs
@@ -41,6 +41,15 @@ namespace DisplayXR
                  "ignored when this is enabled.")]
         public bool foregroundOnlyClip = false;
 
+        [Header("Rendering")]
+
+        [Tooltip("Post-process FXAA on the eye render target. Unity drops MSAA on the XR " +
+                 "eye RT (submits sampleCount=1 and its resolve loses fractional alpha), so " +
+                 "silhouettes alias — most visibly in alpha-native transparent overlays. " +
+                 "FXAA restores soft edges post-resolve where MSAA/supersampling can't. " +
+                 "Disable if you don't need it.")]
+        public bool postProcessAntiAliasing = true;
+
         [Header("Debug")]
 
         [Tooltip("Show eye tracking status in the console.")]
@@ -48,6 +57,7 @@ namespace DisplayXR
 
         private DisplayXRFeature m_Feature;
         private Camera m_Camera;
+        private DisplayXRPostAA m_PostAA;
         // True when running under URP/HDRP. BiRP fires Camera.onPreRender; SRP doesn't,
         // so we route through RenderPipelineManager.beginCameraRendering instead.
         private bool m_UsingSRP;
@@ -62,6 +72,11 @@ namespace DisplayXR
             else
                 Camera.onPreRender += OnCameraPreRender;
             DisplayXRRigManager.Register(m_Camera);
+
+            // Post-process AA: Unity drops MSAA on the XR eye RT, so attach a
+            // (hidden, rig-managed) FXAA pass and mirror the toggle onto it.
+            m_PostAA = DisplayXRPostAA.Ensure(gameObject);
+            m_PostAA.enabled = postProcessAntiAliasing;
 #if !UNITY_EDITOR
             if (m_Feature == null)
             {
@@ -122,6 +137,10 @@ namespace DisplayXR
 
         void LateUpdate()
         {
+            // Keep the post-process AA pass tracking the toggle (inspector or
+            // runtime). Before the active-rig gate so every rig tracks its own flag.
+            if (m_PostAA != null) m_PostAA.enabled = postProcessAntiAliasing;
+
             // Only the active rig pushes tunables (prevents multi-rig conflicts)
             var active = DisplayXRRigManager.ActiveCamera;
             if (active != null && active != m_Camera) return;

--- a/Runtime/DisplayXRPostAA.cs
+++ b/Runtime/DisplayXRPostAA.cs
@@ -1,0 +1,87 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+
+using UnityEngine;
+
+namespace DisplayXR
+{
+    /// <summary>
+    /// Post-process FXAA pass for a DisplayXR rig camera. Managed by the rig
+    /// components (<see cref="DisplayXRCamera"/> / <see cref="DisplayXRDisplay"/>)
+    /// via their <c>postProcessAntiAliasing</c> toggle — not added directly by
+    /// users, so it carries no AddComponentMenu and hides itself from the
+    /// inspector.
+    ///
+    /// Why this exists: Unity 6 + Built-in RP + MultiPass + OpenXR submits the
+    /// XR eye swapchain at sampleCount=1 on both D3D12 and Vulkan, and its eye-RT
+    /// MSAA resolve does not preserve fractional alpha. The result is aliased
+    /// silhouettes (glaring in alpha-native transparent overlays, where the
+    /// aliasing is in the alpha channel). The FXAA shader lerps full RGBA at
+    /// detected edges, restoring soft edges post-resolve where MSAA/supersampling
+    /// can't. Graphics-API agnostic (pure OnRenderImage), works on D3D12 and
+    /// Vulkan alike. Requires MultiPass (single-pass-instanced breaks Blit on the
+    /// eye texture array).
+    /// </summary>
+    [RequireComponent(typeof(Camera))]
+    [DisallowMultipleComponent]
+    public class DisplayXRPostAA : MonoBehaviour
+    {
+        private Material m_Material;
+        private bool m_Warned;
+
+        void OnEnable() => EnsureMaterial();
+
+        void EnsureMaterial()
+        {
+            if (m_Material != null) return;
+            // Resources.Load first (reliable in player builds — Resources content
+            // is always included); Shader.Find as an editor/safety fallback.
+            Shader sh = Resources.Load<Shader>("DisplayXRPostAA");
+            if (sh == null) sh = Shader.Find("Hidden/DisplayXR/PostAA");
+            if (sh != null && sh.isSupported)
+            {
+                m_Material = new Material(sh) { hideFlags = HideFlags.HideAndDontSave };
+            }
+            else if (!m_Warned)
+            {
+                m_Warned = true;
+                Debug.LogWarning("[DisplayXR] Post-process AA shader 'Hidden/DisplayXR/PostAA' " +
+                                 "missing or unsupported; the FXAA pass is a no-op.", this);
+            }
+        }
+
+        void OnRenderImage(RenderTexture src, RenderTexture dst)
+        {
+            if (m_Material != null) Graphics.Blit(src, dst, m_Material);
+            else Graphics.Blit(src, dst);
+        }
+
+        void OnDestroy()
+        {
+            if (m_Material != null)
+            {
+                if (Application.isPlaying) Destroy(m_Material);
+                else DestroyImmediate(m_Material);
+                m_Material = null;
+            }
+        }
+
+        /// <summary>
+        /// Ensure a (hidden) DisplayXRPostAA exists on <paramref name="go"/> and
+        /// return it. Called by the rig components to mirror their
+        /// <c>postProcessAntiAliasing</c> flag onto the effect's enabled state.
+        /// </summary>
+        internal static DisplayXRPostAA Ensure(GameObject go)
+        {
+            var c = go.GetComponent<DisplayXRPostAA>();
+            if (c == null)
+            {
+                c = go.AddComponent<DisplayXRPostAA>();
+                // Implementation detail of the rig — keep it out of the inspector
+                // and out of the scene file; the rig re-creates it on enable.
+                c.hideFlags = HideFlags.HideInInspector | HideFlags.DontSave;
+            }
+            return c;
+        }
+    }
+}

--- a/Runtime/DisplayXRPostAA.cs.meta
+++ b/Runtime/DisplayXRPostAA.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f9b7276480e422d87901b30588b010f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Resources/DisplayXRPostAA.shader
+++ b/Runtime/Resources/DisplayXRPostAA.shader
@@ -1,0 +1,73 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: BSL-1.0
+//
+// Alpha-aware mini-FXAA post pass for DisplayXR rig cameras.
+//
+// Unity 6 + Built-in RP + MultiPass + OpenXR submits the XR eye swapchain at
+// sampleCount=1 (confirmed D3D12 AND Vulkan), and even with an internal MSAA
+// eye RT Unity's resolve does not preserve fractional alpha — so silhouettes
+// (especially in alpha-native transparent overlays) land with binary alpha and
+// alias. This is a luma-edge FXAA that lerps the FULL RGBA texel along the
+// detected edge, so it softens the alpha channel too, sidestepping Unity's
+// broken eye-RT alpha resolve. Driven by DisplayXRPostAA.
+Shader "Hidden/DisplayXR/PostAA"
+{
+    Properties { _MainTex ("Texture", 2D) = "white" {} }
+    SubShader
+    {
+        Cull Off ZWrite Off ZTest Always
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert_img
+            #pragma fragment frag
+            #include "UnityCG.cginc"
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+
+            #define FXAA_SPAN_MAX 8.0
+            #define FXAA_REDUCE_MUL (1.0/8.0)
+            #define FXAA_REDUCE_MIN (1.0/128.0)
+
+            fixed luma(fixed3 rgb) { return dot(rgb, fixed3(0.299, 0.587, 0.114)); }
+
+            fixed4 frag(v2f_img i) : SV_Target
+            {
+                float2 ts = _MainTex_TexelSize.xy;
+                float2 uv = i.uv;
+
+                fixed4 cM    = tex2D(_MainTex, uv);
+                fixed3 rgbNW = tex2D(_MainTex, uv + float2(-1,-1) * ts).rgb;
+                fixed3 rgbNE = tex2D(_MainTex, uv + float2( 1,-1) * ts).rgb;
+                fixed3 rgbSW = tex2D(_MainTex, uv + float2(-1, 1) * ts).rgb;
+                fixed3 rgbSE = tex2D(_MainTex, uv + float2( 1, 1) * ts).rgb;
+                fixed3 rgbM  = cM.rgb;
+
+                fixed lNW = luma(rgbNW), lNE = luma(rgbNE);
+                fixed lSW = luma(rgbSW), lSE = luma(rgbSE);
+                fixed lM  = luma(rgbM);
+                fixed lMin = min(lM, min(min(lNW, lNE), min(lSW, lSE)));
+                fixed lMax = max(lM, max(max(lNW, lNE), max(lSW, lSE)));
+
+                float2 dir;
+                dir.x = -((lNW + lNE) - (lSW + lSE));
+                dir.y =  ((lNW + lSW) - (lNE + lSE));
+
+                float dirReduce = max((lNW + lNE + lSW + lSE) * 0.25 * FXAA_REDUCE_MUL,
+                                      FXAA_REDUCE_MIN);
+                float rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
+                dir = clamp(dir * rcpDirMin, -FXAA_SPAN_MAX, FXAA_SPAN_MAX) * ts;
+
+                fixed4 rA = 0.5 * (tex2D(_MainTex, uv + dir * (1.0/3.0 - 0.5))
+                                 + tex2D(_MainTex, uv + dir * (2.0/3.0 - 0.5)));
+                fixed4 rB = rA * 0.5 + 0.25 * (tex2D(_MainTex, uv + dir * -0.5)
+                                             + tex2D(_MainTex, uv + dir *  0.5));
+                fixed lB = luma(rB.rgb);
+                return (lB < lMin || lB > lMax) ? rA : rB;
+            }
+            ENDCG
+        }
+    }
+    Fallback Off
+}

--- a/Runtime/Resources/DisplayXRPostAA.shader.meta
+++ b/Runtime/Resources/DisplayXRPostAA.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: effd655fc0374d89bba9fa77a614a173
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
Adds an opt-out **post-process FXAA** pass to the DisplayXR rig as the fix for eye-RT silhouette aliasing (#121).

- New `DisplayXRPostAA` (Runtime) — a hidden, rig-managed `OnRenderImage` FXAA pass + `Hidden/DisplayXR/PostAA` shader (in `Runtime/Resources/`, loaded via `Resources.Load` with a `Shader.Find` fallback, matching the existing `DisplayXRFlash`/`Silhouette` shaders).
- New `postProcessAntiAliasing` toggle on `DisplayXRCamera` and `DisplayXRDisplay` (**default ON**), shown in the rig inspector under a new **Rendering** section. The rig attaches the hidden effect on enable and mirrors the flag onto it (inspector + runtime both apply).

## Why
Unity 6 + Built-in RP + MultiPass + OpenXR submits the XR eye swapchain at `sampleCount=1` on **both D3D12 and Vulkan**, and its eye-RT MSAA resolve does not preserve fractional alpha (verified via the plugin's `xrCreateSwapchain` hook + `XRSettings.eyeTextureDesc`). Result: aliased silhouettes, glaring in alpha-native transparent overlays where the aliasing is in the alpha channel. Hardware MSAA and supersampling don't fix it (same broken resolve, and live `eyeTextureResolutionScale` changes additionally crash the runtime weaver — displayxr-runtime#314). A **post-resolve FXAA that lerps full RGBA** sidesteps Unity's resolve entirely and restores soft edges.

This is a rig/rendering concern (applies to all content, opaque or transparent), so it lives on the rig — not in the transparent-overlay code.

## Test plan
- [x] Verified on **D3D12** in `displayxr-unity-test-transparent`: default-on FXAA cleans up the flat-shaded ghost's silhouette; runtime toggle (F7 in the test harness flips `postProcessAntiAliasing`) shows clear before/after.
- [x] Verified on **Vulkan** (same scene) earlier in the investigation — identical behaviour, confirming the pass is graphics-API agnostic.
- [x] Inspector shows the **Rendering → Post-Process AA (FXAA)** toggle on both rig types.
- [ ] CI builds Windows DLL + macOS Universal bundle (C#-only change; native untouched).

## Notes
- Pure `OnRenderImage` post-process — requires **MultiPass** (single-pass-instanced breaks `Blit` on the eye texture array). DisplayXR rigs are MultiPass.
- Default-on changes behaviour for all consumers (extra per-eye FXAA blit). Intended: it restores the AA Unity drops on the XR eye RT. Disable via the inspector toggle if not wanted.
- Independent of the Vulkan backend work (PR #123) — branched off `main`.