### PR TITLE
ci: drift-guard — fail if displayxr::math is re-vendored [#396 W5]

### DIFF
--- a/.github/workflows/no-vendored-math.yml
+++ b/.github/workflows/no-vendored-math.yml
@@ -1,0 +1,36 @@
+name: drift-guard
+
+# Epic #396: the shared off-axis Kooima math (display3d_view / camera3d_view)
+# lives in displayxr::math and is consumed via FetchContent / submodule. It must
+# NOT be re-vendored into this repo's tracked sources — re-copying it is exactly
+# how the 6x drift this epic killed got started. This guard fails if a vendored
+# copy reappears.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: drift-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-vendored-math:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No re-vendored displayxr::math sources
+        shell: bash
+        run: |
+          # FetchContent copies live in _deps/ (gitignored) and a git submodule's
+          # files are not parent-tracked, so neither trips this check.
+          hits=$(git ls-files | grep -E '(^|/)(display3d_view|camera3d_view)\.(c|h)$' || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Re-vendored displayxr::math sources found. The off-axis Kooima"
+            echo "::error::math must come from displayxr::math (FetchContent / submodule),"
+            echo "::error::not be copied into this repo. See epic #396."
+            echo "$hits"
+            exit 1
+          fi
+          echo "OK: no vendored display3d_view / camera3d_view sources."


### PR DESCRIPTION
Locks in W3: fails CI if the shared Kooima math (`display3d_view`/`camera3d_view`) is re-vendored into the tree (it must come from `displayxr::math` via submodule/FetchContent). Fast git ls-files+grep check; the submodule's files are not parent-tracked so they don't trip it. Verified clean on current main.