### PR TITLE
ci: bump actions to Node 24 runtimes ahead of the June 16 default flip

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -30,7 +30,7 @@ jobs:
     name: Windows x64
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure CMake
         run: cmake -S native~ -B native~/build -A x64 -DCMAKE_BUILD_TYPE=Release
@@ -48,7 +48,7 @@ jobs:
           Get-Item "Runtime/Plugins/Windows/x64/displayxr_unity.dll" | Select-Object Name, Length
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: displayxr_unity-windows-x64
           path: Runtime/Plugins/Windows/x64/displayxr_unity.dll
@@ -57,7 +57,7 @@ jobs:
     name: macOS (Universal)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Configure CMake
         run: cmake -S native~ -B native~/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
@@ -77,7 +77,7 @@ jobs:
           file "$BUNDLE/displayxr_unity" 2>/dev/null || file "$BUNDLE/Contents/MacOS/displayxr_unity" 2>/dev/null || echo "Binary location varies by CMake version"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: displayxr_unity-macos
           path: Runtime/Plugins/macOS/displayxr_unity.bundle
@@ -91,16 +91,16 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: displayxr_unity-windows-x64
           path: Runtime/Plugins/Windows/x64/
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: displayxr_unity-macos
           path: Runtime/Plugins/macOS/
@@ -231,22 +231,22 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download Windows artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: displayxr_unity-windows-x64
           path: Runtime/Plugins/Windows/x64/
 
       - name: Download macOS artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: displayxr_unity-macos
           path: Runtime/Plugins/macOS/
 
       - name: Upload combined artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: displayxr-unity-plugin
           path: |

--- a/.github/workflows/no-vendored-math.yml
+++ b/.github/workflows/no-vendored-math.yml
@@ -19,7 +19,7 @@ jobs:
   no-vendored-math:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: No re-vendored displayxr::math sources
         shell: bash
         run: |


### PR DESCRIPTION
GitHub flips JavaScript actions to a Node 24 default on **June 16**. Bump every action pin to the lowest major that declares `runs.using: node24` (each verified against the tag's `action.yml`). Org-wide sweep; runtime already landed as displayxr-runtime#554.

Mapping: checkout v4→v5, cache v4→v5, upload-artifact v4→v6, download-artifact v4→v7 (v5's breaking path change only affects `artifact-ids:` downloads; ours are by `name:`), setup-java v4→v5, setup-node v4→v5, create-github-app-token v1→v3 (same inputs), repository-dispatch v3→v4, action-gh-release v2→v3, gha-setup-ninja v4→v6 (newest available; Node 20 — no Node 24 release upstream yet).

Left as-is (no Node 24 release exists; will be force-run on Node 24 and expected to work): `ilammy/msvc-dev-cmd@v1`. Already Node 24: `lukka/run-vcpkg@v11`, `nttld/setup-ndk@v1`; `humbletim/install-vulkan-sdk@v1.2` is composite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
