### PR TITLE
Release v1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the DisplayXR Unity plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.20.0] - 2026-06-15
 
 ### Added
 - **URP off-axis projection fix** (#127/#129): URP ignores `Camera.SetStereoProjectionMatrix` (Unity #1328435) and builds each eye's projection from `views[i].fov`, which it mishandles for strongly off-center window-relative Kooima frustums (head x<0 shifts/deforms — the prior "URP off-center" known limitation). A new URP-guarded sub-assembly (`Runtime/URP/`, `Editor/URP/`) ships **`KooimaProjectionFixFeature`**, a `ScriptableRendererFeature` that re-pushes the runtime's correct per-eye `leftProj`/`rightProj` via `cmd.SetViewProjectionMatrices` at `BeforeRenderingOpaques` (URP pushes the projection once per eye-pass at camera setup, so it sticks). Has a NaN/identity startup guard. **Auto-wired** into the URP renderer when a DisplayXR rig is in an open scene (`DisplayXRUrpAutoWire`; toggle `DisplayXR > Auto-Wire URP Projection Fix`, or run `DisplayXR > Setup URP Projection Fix`).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.displayxr.unity",
   "displayName": "DisplayXR",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "unity": "2022.3",
   "description": "Unity plugin for DisplayXR OpenXR runtime enabling stereo rendering on 3D light field displays. Provides display-centric and camera-centric stereo rig authoring, Kooima asymmetric frustum projection, 2D UI overlay support, and in-editor preview.",
   "keywords": [


### PR DESCRIPTION
Release v1.20.0 — version bump + CHANGELOG header rename for the URP off-axis projection fix (#127/#129).

Branch protection on `main` requires the 3 status checks (Windows x64, macOS Universal, no-vendored-math) to pass on the release commit; this PR runs them. Once green, the commit is fast-forwarded onto main and the `v1.20.0` tag is pushed to trigger the release job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)