### PR TITLE
fix(urp): render each eye with the runtime eye_world view (#127)

### DIFF
--- a/Runtime/URP/KooimaProjectionFixFeature.cs
+++ b/Runtime/URP/KooimaProjectionFixFeature.cs
@@ -88,9 +88,17 @@ namespace DisplayXR.URP
                     }
                 }
 
-                // Keep URP's view (it's correct, from the provider); replace only the
-                // projection. SetViewProjectionMatrices expects the non-GPU projection.
-                Matrix4x4 view = xr.GetViewMatrix(0);
+                // Use the runtime eye_world VIEW too — NOT URP's view. URP's view
+                // comes from the head-pose-compensated pose (#115), which diverges
+                // from the eye_world position the projection is built for as the
+                // head moves off-centre. Pairing eye_world proj with URP's view made
+                // the rendered parallax track the head FASTER than the click-through
+                // silhouette (which uses eye_world view+proj, same as BiRP) — so the
+                // tiger slid out from under its own silhouette/mask. Pairing eye_world
+                // view AND proj makes URP render identical to BiRP and the silhouette.
+                // FlipZ → Unity convention (the rig's FlipViewZ before SetStereoView).
+                // SetViewProjectionMatrices expects the non-GPU projection.
+                Matrix4x4 view = FlipZ(isLeft ? lv : rv);
 
                 if (m_LogCount < 4)
                 {


### PR DESCRIPTION
**Bug:** `KooimaProjectionFixFeature` re-pushed the runtime's per-eye **projection** but kept **URP's own view**. URP's view derives from the head-pose-compensated pose (#115), which diverges from the eye_world position the projection is built for as the head moves off-centre. So the URP render parallax tracked the head *faster* than `GetStereoMatrices` (used by BiRP + the click-through silhouette). HW symptom: pop content out front + move head sideways → it slid out from under its own silhouette/mask, leaving transparent holes.

**Fix:** push the runtime eye_world **view** too (`FlipZ(lv/rv)` → Unity convention), so URP renders with the same view+projection as BiRP and the silhouette. Hardware-verified (RTX 3080 / D3D12 / URP 17).