### PR TITLE
Release v1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.displayxr.unity",
   "displayName": "DisplayXR",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "unity": "2022.3",
   "description": "Unity plugin for DisplayXR OpenXR runtime enabling stereo rendering on 3D light field displays. Provides display-centric and camera-centric stereo rig authoring, Kooima asymmetric frustum projection, 2D UI overlay support, and in-editor preview.",
   "keywords": [


### PR DESCRIPTION
Bumps package.json to 1.22.0 for the v1.22.0 release.

Ships the shell render + input fixes for Unity apps (#160): apps now render and accept WASDQE + mouse drag under the DisplayXR shell (workspace mode).

Merge then tag v1.22.0 to trigger the native build + UPM/GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)