### PR TITLE
Release v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the DisplayXR Unity plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.23.0] - 2026-06-28
+
+### Added
+- **Single-Pass-Instanced (SPI) stereo rendering** on URP + Windows + D3D12, auto-gated by platform and runtime version (requires DisplayXR runtime >= v1.26.1); falls back to MultiPass otherwise (#162).
+
+### Changed
+- Rewrote `docs~/architecture/hook-chain.md`: two rendering paths, `PRIMARY_STEREO` clarification, SPI corollary, and an overlay/runtime-integration note (#163).
+
 ## [1.21.0] - 2026-06-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.displayxr.unity",
   "displayName": "DisplayXR",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "unity": "2022.3",
   "description": "Unity plugin for DisplayXR OpenXR runtime enabling stereo rendering on 3D light field displays. Provides display-centric and camera-centric stereo rig authoring, Kooima asymmetric frustum projection, 2D UI overlay support, and in-editor preview.",
   "keywords": [


### PR DESCRIPTION
Plugin v1.23.0: Single-Pass-Instanced (SPI) rendering support (URP + Windows + D3D12, auto-gated on runtime >= v1.26.1) + hook-chain doc rewrite. Version bump + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)