### PR TITLE
docs: correct view-synthesis hallucination (built apps are 2-view only)

### DIFF
--- a/Runtime/DisplayXRFeature.cs
+++ b/Runtime/DisplayXRFeature.cs
@@ -192,10 +192,10 @@ namespace DisplayXR
             //
             // Eligibility is purely platform/pipeline — the *view-count* condition is
             // always satisfied: the Unity built-app path is always 2-view
-            // (PRIMARY_STEREO); N-view quad/lenticular output is synthesised by the
-            // runtime's Display Processor downstream (distinct N-view rendering only
-            // happens in the editor standalone preview's own multi-camera session, never
-            // through the built-app stereo pipeline). KooimaProjectionFixFeature's
+            // (PRIMARY_STEREO). There is no view synthesis downstream, so a built Unity
+            // app is limited to display modes with view count <= 2; distinct N-view
+            // rendering only happens in the editor standalone preview's own multi-camera
+            // session, never through the built-app stereo pipeline. KooimaProjectionFixFeature's
             // per-frame `xr.viewCount == 2` is the belt-and-suspenders guard. SPI also
             // requires a runtime new enough to carry the imageArrayIndex fix; ship the
             // plugin and runtime together (see docs~/experiments/spi-single-pass.md).

--- a/Runtime/URP/KooimaProjectionFixFeature.cs
+++ b/Runtime/URP/KooimaProjectionFixFeature.cs
@@ -129,8 +129,9 @@ namespace DisplayXR.URP
                 // the off-axis (#127) correction for the SPI path.
                 //
                 // GATE: exactly 2 views in this single pass. The Unity built-app path is
-                // always PRIMARY_STEREO, so this holds; the runtime synthesises N-view
-                // quad/lenticular downstream (see hook-chain.md). Requires a DisplayXR
+                // always PRIMARY_STEREO, so this holds; a built Unity app renders only
+                // 2 views and there is no view synthesis downstream, so it is limited to
+                // <=2-view display modes (see hook-chain.md). Requires a DisplayXR
                 // runtime that samples per-view subImage.imageArrayIndex — otherwise the
                 // compositor reads array layer 0 for both eyes and the image is flat.
                 // Verified on Windows/D3D12 (see docs~/experiments/spi-single-pass.md).

--- a/docs~/architecture/hook-chain.md
+++ b/docs~/architecture/hook-chain.md
@@ -89,14 +89,17 @@ composition layers: `XrCompositionLayerWindowSpaceEXT` (2D UI), `XrCompositionLa
 | **Built app** (this doc) | Unity's loader session | yes (`hooked_*`) | **always 2** eyes |
 | **Standalone preview / Play Mode** | plugin-owned SA session | **no** (calls the real entry points directly) | **N** (2/4/8) via a multi-camera atlas rig |
 
-A built Unity app **renders and submits only its 2 eyes**; the runtime's Display Processor
-synthesises the extra quad/lenticular views (4/8) downstream. Distinct N-view *rendering*
-exists only in the standalone preview, where the plugin runs its **own** OpenXR session
-(view capacity 32) and renders one Unity `Camera` per view into an atlas RenderTexture —
-not Unity's stereo pipeline. (`hooked_xrLocateViews` may receive `*viewCountOutput` = the
-display's **max-mode** view count — 2 on a Leia 2D/3D panel, up to 4/8 on quad/lenticular —
-so the `count > 2` loop is **real on multi-view displays**, not dead; but Unity still
-submits 2-eye projection layers. See the note below.)
+A built Unity app **renders and submits only its 2 eyes**. **There is no view synthesis
+downstream** — nothing reconstructs additional views from those 2 eyes, so a built Unity app
+can only drive display modes whose view count is ≤ 2; a mode with more views (e.g. a 2×2 Quad
+mode, `view_count = 4`) requires the app to render all N views itself. Distinct N-view
+*rendering* exists only in the standalone preview, where the plugin runs its **own** OpenXR
+session (view capacity 32) and renders one Unity `Camera` per view into an atlas RenderTexture
+— not Unity's stereo pipeline. (`hooked_xrLocateViews` may receive `*viewCountOutput` = the
+display's **max-mode** view count — 2 on a 2-view eye-tracked panel, up to 4 on a Quad/N-view
+display — so the `count > 2` loop is **real on multi-view displays**, not dead; but Unity still
+submits 2-eye projection layers, which is exactly why it is limited to ≤2-view modes. See the
+note below.)
 
 > **The view-configuration type is *not* what makes this 2-view.** The DisplayXR runtime
 > advertises only `XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO` to **every** app — native
@@ -105,8 +108,9 @@ submits 2-eye projection layers. See the note below.)
 > accepts a projection `viewCount` matching *any* mode's `view_count`). The difference is
 > what each app *does* with that: a native handle app renders the active mode's **N views as
 > tiles in one worst-case-sized swapchain** (multiview tiling, ADR-010); the Unity built app
-> renders **only the 2 eyes** and lets the DP synthesise the rest. So "always 2-view" is a
-> property of the **Unity built-app submission model**, not of `PRIMARY_STEREO`.
+> renders **only the 2 eyes**, so it is restricted to modes with view count ≤ 2 (there is no
+> view synthesis to fill the rest). So "always 2-view" is a property of the **Unity built-app
+> submission model**, not of `PRIMARY_STEREO`.
 
 ## Rendering model: native handle app vs Unity plugin
 
@@ -157,9 +161,9 @@ Wherever the atlas composite reads the per-view source it must sample the layer 
 **SPI eligibility:** SPI is structurally a 2-view feature, and what matters is Unity's
 **rendered** view count — `xr.viewCount` (the URP `XRPass`), which is the 2 eyes Unity
 submits, *not* the native locate `*viewCountOutput` (the display's max-mode count). Unity
-renders 2 eyes regardless of the display's lenticular view count (those are DP-synthesised),
-so SPI is valid; the per-frame `xr.viewCount == 2` guard in `KooimaProjectionFixFeature`
-enforces it.
+renders 2 eyes regardless of the display's lenticular view count (Unity simply cannot drive
+modes that need more than 2 views — there is no view synthesis), so SPI is valid; the
+per-frame `xr.viewCount == 2` guard in `KooimaProjectionFixFeature` enforces it.
 
 ## Thread-safe shared state
 


### PR DESCRIPTION
Built Unity apps render and submit exactly 2 views; there is **no downstream view synthesis**, so they are limited to display modes with `view_count <= 2`. Modes with more views (e.g. a 2x2 Quad mode, `view_count=4`) require the app to render all N tiles itself.

Fixes the same wrong "DP synthesises 4/8 views" claim in:
- `docs~/architecture/hook-chain.md` (3 passages; also de-vendored a stray panel reference)
- `Runtime/DisplayXRFeature.cs` (comment-only)
- `Runtime/URP/KooimaProjectionFixFeature.cs` (comment-only)

No behavior change — comments + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)