### PR TITLE
feat(signing): SIGN_CMD-gated signing of the native plugin DLL (#666)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -147,8 +147,65 @@ Run: `gh run watch RUN_ID --interval 15` (timeout 600000ms)
 
 ### Step 3.4: Check result
 Run: `gh run view RUN_ID --json status,conclusion`
-- If success: continue to Phase 4
+- If success: continue to Phase 3.5
 - If failure: Go to PHASE 5 (Rollback)
+
+---
+
+## PHASE 3.5: CODE-SIGN THE WINDOWS NATIVE PLUGIN (capability-gated)
+
+`displayxr_unity.dll` is the native plugin that loads into the Unity
+player, so Smart App Control blocks it when unsigned. CI builds it on a
+GitHub-hosted runner (unsigned; the code-signing key is held on a build
+machine and isn't available to cloud CI, and no secret lives in this
+public repo). So a signed release is produced by signing the shipped DLL
+on a signing-capable machine and re-publishing.
+
+Signing does **not** require rebuilding — we sign the CI-built DLL in
+place inside both distribution channels (the `.tgz` asset and the `upm`
+orphan branch). No-ops cleanly without signing capability.
+
+### Step 3.5.1: Capability check
+```bash
+if [ -z "$SIGN_CMD" ] || ! uname -s | grep -qiE 'mingw|msys|cygwin|windows'; then
+  echo "⚠  SIGNING SKIPPED — no signing capability; release DLL stays UNSIGNED."
+  echo "   Re-run /release on a signing-capable build machine (SIGN_CMD set)."
+  SIGNED=no   # continue — do not fail
+else
+  SIGNED=yes
+fi
+```
+
+### Step 3.5.2: Sign the DLL in the `.tgz` asset, repack, re-upload (if SIGNED=yes)
+```bash
+TGZ="com.displayxr.unity-[VERSION_NUMBER].tgz"
+gh release download [VERSION] --repo DisplayXR/displayxr-unity --pattern "$TGZ" --dir /tmp/usign
+mkdir -p /tmp/usign/x && tar -xzf "/tmp/usign/$TGZ" -C /tmp/usign/x
+DLL=$(find /tmp/usign/x -ipath '*Windows/x64/displayxr_unity.dll')
+powershell -NoProfile -ExecutionPolicy Bypass -File Scripts\\sign-release.ps1 -Path "$(dirname "$DLL")" -SignCmd "$SIGN_CMD"
+# repack with the same internal layout (npm packages root at 'package/')
+( cd /tmp/usign/x && tar -czf "/tmp/usign/$TGZ" package )
+gh release upload [VERSION] "/tmp/usign/$TGZ" --clobber --repo DisplayXR/displayxr-unity
+```
+
+### Step 3.5.3: Sign the DLL on the `upm` branch too
+Users who install by git URL get the DLL from the `upm` orphan branch,
+not the `.tgz` — sign that copy as well.
+```bash
+git fetch origin upm && git checkout upm
+powershell -NoProfile -ExecutionPolicy Bypass -File Scripts\\sign-release.ps1 \
+  -Path "Runtime/Plugins/Windows/x64" -SignCmd "$SIGN_CMD"
+git commit -am "Sign displayxr_unity.dll for [VERSION]"
+git push origin upm
+# move the upm/[VERSION] tag onto the signed commit so the pinned install is signed too
+git tag -f "upm/[VERSION]" && git push -f origin "upm/[VERSION]"
+git checkout main
+```
+
+Note: the macOS `displayxr_unity.bundle` is signed with an Apple
+Developer ID cert + notarization (a separate track from the Windows EV
+cert) — out of scope here; flag it as macOS-unsigned in the report.
+Carry `SIGNED` into the final report.
 
 ---
 

--- a/Scripts/sign-release.ps1
+++ b/Scripts/sign-release.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+  Sign all DisplayXR-produced binaries in a release folder, then verify the
+  whole tree is signed.
+
+.DESCRIPTION
+  Signing is driven entirely by the command passed in -SignCmd (sourced from
+  the SIGN_CMD environment variable by the build scripts). This script holds
+  NO certificate and NO secret. On machines without signing capability,
+  SIGN_CMD is unset and the build scripts skip signing — the build is
+  unsigned, with no behavior change.
+
+    1. Walk the folder for *.dll / *.exe.
+    2. Any binary WITHOUT a Valid Authenticode signature -> sign it via the
+       configured signer. Binaries that already carry a valid signature
+       (e.g. bundled third-party DLLs) are left untouched.
+    3. Re-verify the ENTIRE tree. If anything is still unsigned, FAIL (exit 1).
+
+  -SignCmd receives the file path as a trailing argument. Callers pass a full
+  signing command (including their own timestamp authority) via SIGN_CMD; the
+  default below is a minimal fallback for ad-hoc use.
+
+.EXAMPLE
+  # sign a staged binary tree before packaging
+  .\sign-release.ps1 -Path .\_package\bin -SignCmd "$env:SIGN_CMD"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+
+    # Signing command; receives the file path as a trailing argument.
+    # Production callers pass a full command (with a timestamp authority)
+    # via the SIGN_CMD environment variable. This default is a bare fallback.
+    [string]$SignCmd = 'signtool sign /fd sha256 /a',
+
+    # Skip signing files already validly signed by anyone (default). Use
+    # -Force to re-sign every binary regardless (overwrites existing sigs).
+    [switch]$Force
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-Signed($file) {
+    (Get-AuthenticodeSignature $file).Status -eq 'Valid'
+}
+
+function Invoke-Sign($file) {
+    $parts = $SignCmd -split '\s+'
+    $exe   = $parts[0]
+    $args  = @($parts[1..($parts.Length - 1)]) + $file
+    & $exe @args
+    if ($LASTEXITCODE -ne 0) { throw "Signing failed for $file (exit $LASTEXITCODE)" }
+}
+
+if (-not (Test-Path $Path)) { throw "Path not found: $Path" }
+
+$binaries = Get-ChildItem -Path $Path -Recurse -Include *.dll, *.exe -File
+Write-Host "Found $($binaries.Count) binaries under $Path"
+
+$signed = 0; $skipped = 0
+foreach ($b in $binaries) {
+    if (-not $Force -and (Test-Signed $b.FullName)) {
+        $who = (Get-AuthenticodeSignature $b.FullName).SignerCertificate.Subject
+        Write-Host "  skip (already signed) : $($b.Name)  <$who>"
+        $skipped++
+        continue
+    }
+    Write-Host "  signing               : $($b.Name)"
+    Invoke-Sign $b.FullName
+    $signed++
+}
+
+Write-Host "Signed $signed, skipped $skipped already-signed."
+
+# ---- Verification gate ----
+$unsigned = $binaries | Where-Object { -not (Test-Signed $_.FullName) }
+if ($unsigned) {
+    Write-Host "`nFAIL: the following binaries are still unsigned:" -ForegroundColor Red
+    $unsigned | ForEach-Object { Write-Host "  $($_.FullName)" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host "`nOK: all $($binaries.Count) binaries under $Path are signed." -ForegroundColor Green


### PR DESCRIPTION
Adds capability-gated (`SIGN_CMD`) code-signing of the shipped native plugin DLL so a released package is Authenticode-signed and won't be blocked by the OS application-control policy that rejects unsigned native DLLs.

Part of the bundle-wide signing rollout tracked in #666. This component has no NSIS installer, so signing happens in the release/package step (shape B) rather than in an installer build — the CI-built DLL is signed in place in both distribution channels.

## What changed
- **`Scripts/sign-release.ps1`** — signs any `*.dll`/`*.exe` lacking a Valid Authenticode signature via the command in `SIGN_CMD`, then fails if anything is left unsigned. Carries no certificate and no secret (same script used across the other bundle components).
- **`.claude/skills/release/SKILL.md`** — new Phase 3.5 that, only when `SIGN_CMD` is set and the host is a signing-capable Windows machine, signs the native DLL inside the `.tgz` release asset (download → extract → sign → repack → re-upload) and on the `upm` orphan branch (sign → commit → move the pinned tag onto the signed commit). No rebuild needed. Without signing capability it logs a skip and leaves the package unsigned, exactly as before.

The macOS native bundle stays on its separate Apple Developer ID / notarization track and is out of scope here.

## Why no secret lives here
Signing is driven entirely by the `SIGN_CMD` env var, set only on a signing-capable build machine. Cloud CI and clones leave it unset and produce an unsigned package with no behavior change.

## Validation
With a throwaway self-signed cert, running `sign-release.ps1` against the CI-built native DLL took it from NotSigned to Authenticode-**Valid** and it passes `signtool verify /pa`. The same `sign-release.ps1` is already validated across the runtime + the other bundle components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)