### PR TITLE
Vendor-neutral NOTICE; keep vendored OpenXR headers BSL-1.0

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 DisplayXR Unity Plugin
-Copyright (c) 2024-2026 Leia, Inc. and the DisplayXR project contributors
+Copyright (c) 2024-2026 The DisplayXR Project and its contributors
 
-This product includes software developed by Leia, Inc. and the DisplayXR
-project contributors. It is licensed under the Apache License, Version 2.0;
-see the LICENSE file for the full text.
+This product includes software developed by the DisplayXR project contributors.
+It is licensed under the Apache License, Version 2.0; see the LICENSE file for
+the full text.


### PR DESCRIPTION
Follow-up to the Apache-2.0 relicense.

- **NOTICE** no longer names the vendor — **vendor-neutrality contract** (only the Leia plug-in repo may name the vendor). Copyright holder is now "The DisplayXR Project and its contributors".
- Vendored **OpenXR extension headers** under `*/openxr/` are copied verbatim from the **BSL-1.0 runtime**, so they are reverted to **BSL-1.0** (copied-runtime code, per the relicense guardrail). Authored code stays Apache-2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)