### PR TITLE
Release v1.24.1 — deploy native provider into player builds (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the DisplayXR Unity plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-07-02
+
+### Fixed
+- **Native provider now deploys into player builds (#166).** Unity's player build did not
+  auto-include this package's native library (`displayxr_unity`) or its
+  `UnitySubsystemsManifest.json` — unlike a first-party XR package, the custom
+  `IUnityXRDisplay` provider package isn't recognized by Unity's XR build pipeline, so a clean
+  consumer build shipped without the native provider and the app failed to weave. A new post-build
+  step (`DisplayXRProviderRuntimeDeploy`) copies the shipped native binary + subsystem manifest into
+  the player's data folder (Windows `_Data/Plugins/x86_64` + `_Data/UnitySubsystems/DisplayXR`; the
+  macOS `.app` equivalents), mirroring how the existing build processor deploys the macOS OpenXR
+  loader. Fixes clean `#upm` consumer builds (previously the bits had to be hand-copied).
+
 ## [1.24.0] - 2026-07-02
 
 The custom **`IUnityXRDisplay` display provider becomes the shipping rendering path** (epic #166). The provider drives the DisplayXR runtime directly — Single-Pass-Instanced on URP + Windows + D3D12, MultiPass elsewhere — replacing the legacy native OpenXR-hook path for the primary workflow. The old `DisplayXRFeature` hook is soft-deprecated (`[Obsolete]`) but still functional. The repository is relicensed to **Apache-2.0**.

--- a/Editor/DisplayXRProviderRuntimeDeploy.cs
+++ b/Editor/DisplayXRProviderRuntimeDeploy.cs
@@ -1,0 +1,130 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using System;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace DisplayXR.Editor
+{
+    /// <summary>
+    /// Post-build step that deploys the DisplayXR native plugin and its XR
+    /// subsystem manifest into the built player.
+    ///
+    /// Unity's player build does NOT reliably auto-include this package's native
+    /// library (<c>displayxr_unity</c>) or its <c>UnitySubsystemsManifest.json</c>:
+    /// unlike a first-party XR package (e.g. com.unity.xr.openxr, whose manifest +
+    /// native loader the OpenXR build processor copies), our custom
+    /// <c>IUnityXRDisplay</c> provider package is not recognized by Unity's XR
+    /// build pipeline, so a clean consumer build ships without the native provider
+    /// and the app fails to weave (#166). Throughout development this was masked by
+    /// hand-copying the DLL + manifest after every build.
+    ///
+    /// This processor closes that gap the same way <see cref="DisplayXRBuildProcessor"/>
+    /// deploys the macOS OpenXR loader: copy the package's shipped native binary and
+    /// subsystem manifest into the player's data folder if Unity didn't. It runs for
+    /// both the provider and the legacy hook path (both need the native library); the
+    /// manifest is inert when no DisplayXR display loader is active, so deploying it
+    /// unconditionally is safe.
+    /// </summary>
+    public class DisplayXRProviderRuntimeDeploy : IPostprocessBuildWithReport
+    {
+        // After DisplayXRBuildProcessor (100) is not required; run early so the
+        // native bits are in place regardless of other processors.
+        public int callbackOrder => 60;
+
+        const string PackageRoot = "Packages/com.displayxr.unity";
+        // Subsystem-manifest folder name in the player = the manifest "name" field.
+        const string SubsystemName = "DisplayXR";
+
+        public void OnPostprocessBuild(BuildReport report)
+        {
+            var platform = report.summary.platform;
+            string pkgRoot;
+            try { pkgRoot = Path.GetFullPath(PackageRoot); }
+            catch { pkgRoot = null; }
+
+            if (string.IsNullOrEmpty(pkgRoot) || !Directory.Exists(pkgRoot))
+            {
+                // Dev checkout where the package isn't under Packages/ (rare). The
+                // file:/embedded dev flows already manage the native bits manually.
+                Debug.LogWarning("[DisplayXR] Provider deploy: package not found under " +
+                                 PackageRoot + " — skipping native/manifest deploy.");
+                return;
+            }
+
+            string manifestSrc = Path.Combine(pkgRoot, "Runtime", "UnitySubsystemsManifest.json");
+            string outputPath = report.summary.outputPath;
+
+            if (platform == BuildTarget.StandaloneWindows64 || platform == BuildTarget.StandaloneWindows)
+            {
+                string exeDir = Path.GetDirectoryName(outputPath);
+                string exeName = Path.GetFileNameWithoutExtension(outputPath);
+                string dataDir = Path.Combine(exeDir, exeName + "_Data");
+                string dllSrc = Path.Combine(pkgRoot, "Runtime", "Plugins", "Windows", "x64", "displayxr_unity.dll");
+
+                CopyFileInto(dllSrc, Path.Combine(dataDir, "Plugins", "x86_64", "displayxr_unity.dll"));
+                CopyFileInto(manifestSrc, Path.Combine(dataDir, "UnitySubsystems", SubsystemName, "UnitySubsystemsManifest.json"));
+            }
+            else if (platform == BuildTarget.StandaloneOSX)
+            {
+                // .app: native plugin lives in Contents/PlugIns, engine data in
+                // Contents/Resources/Data (mirrors CopyMacOSOpenXRLoader).
+                string bundleSrc = Path.Combine(pkgRoot, "Runtime", "Plugins", "macOS", "displayxr_unity.bundle");
+                CopyBundleInto(bundleSrc, Path.Combine(outputPath, "Contents", "PlugIns", "displayxr_unity.bundle"));
+                CopyFileInto(manifestSrc, Path.Combine(outputPath, "Contents", "Resources", "Data",
+                    "UnitySubsystems", SubsystemName, "UnitySubsystemsManifest.json"));
+            }
+            // Other standalone targets (Linux) are not shipped for the provider today.
+        }
+
+        static void CopyFileInto(string src, string dst)
+        {
+            if (!File.Exists(src))
+            {
+                Debug.LogWarning($"[DisplayXR] Provider deploy: source missing, not copied: {src}");
+                return;
+            }
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(dst));
+                File.Copy(src, dst, overwrite: true);
+                Debug.Log($"[DisplayXR] Provider deploy: {Path.GetFileName(dst)} -> {dst}");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[DisplayXR] Provider deploy: failed to copy {src} -> {dst}: {e.Message}");
+            }
+        }
+
+        static void CopyBundleInto(string srcDir, string dstDir)
+        {
+            if (!Directory.Exists(srcDir))
+            {
+                Debug.LogWarning($"[DisplayXR] Provider deploy: macOS bundle missing, not copied: {srcDir}");
+                return;
+            }
+            try
+            {
+                CopyDirRecursive(srcDir, dstDir);
+                Debug.Log($"[DisplayXR] Provider deploy: displayxr_unity.bundle -> {dstDir}");
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[DisplayXR] Provider deploy: failed to copy bundle {srcDir} -> {dstDir}: {e.Message}");
+            }
+        }
+
+        static void CopyDirRecursive(string src, string dst)
+        {
+            Directory.CreateDirectory(dst);
+            foreach (string file in Directory.GetFiles(src))
+                File.Copy(file, Path.Combine(dst, Path.GetFileName(file)), overwrite: true);
+            foreach (string dir in Directory.GetDirectories(src))
+                CopyDirRecursive(dir, Path.Combine(dst, Path.GetFileName(dir)));
+        }
+    }
+}

--- a/Editor/DisplayXRProviderRuntimeDeploy.cs.meta
+++ b/Editor/DisplayXRProviderRuntimeDeploy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24e9930da3bd58f48979704857ae01b0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.displayxr.unity",
   "displayName": "DisplayXR",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "unity": "2022.3",
   "description": "Unity plugin for DisplayXR OpenXR runtime enabling stereo rendering on 3D light field displays. Provides display-centric and camera-centric stereo rig authoring, Kooima asymmetric frustum projection, 2D UI overlay support, and in-editor preview.",
   "keywords": [


### PR DESCRIPTION
Patch: fixes clean `#upm` consumer builds not including the native provider DLL + subsystem manifest (they had to be hand-copied). New post-build processor `DisplayXRProviderRuntimeDeploy` deploys them, mirroring the existing macOS OpenXR-loader deploy. Validated on displayxr-unity-test-2d-ui (clean build auto-deploys both; provider FOCUSED).