### PR TITLE
chore: drop com.unity.xr.openxr dep + remove dead hook exports (#166)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,16 @@ Extension struct definitions in `native~/displayxr_extensions.h` must match the 
 4. Set `XR_RUNTIME_JSON` environment variable to point to a DisplayXR runtime build (or use `SIM_DISPLAY_ENABLE=1 SIM_DISPLAY_OUTPUT=sbs` for testing without hardware)
 5. **Press Play** — Play Mode runs the provider and *is* the preview (identical to a built player); there is no separate preview window
 
-### OpenXR package dependency (provider does not use Unity's OpenXR loader)
+### No dependency on Unity's OpenXR package (the provider drives OpenXR itself)
 
-`package.json` still depends on `com.unity.xr.openxr` (`DisplayXRLocal2D` references `OpenXRRuntime.IsExtensionEnabled`), but the provider is a custom **`IUnityXRDisplay`** subsystem — it drives the DisplayXR runtime directly and **does not enable Unity's OpenXR loader**. So the old hook-era caveat (pre-1.16.1 OpenXR silently ignoring `XR_RUNTIME_JSON` in editor play mode and falling back to the Mock Runtime → `0x0` resolution) no longer applies: the provider never routes through Unity's OpenXR loader. Enable **DisplayXR** (not OpenXR) in XR Plug-in Management.
+The plugin has **no dependency on `com.unity.xr.openxr`** — it was dropped once the last
+consumer (`DisplayXRLocal2D`'s `OpenXRRuntime.IsExtensionEnabled` gate, always false in
+provider mode) was provider-ized. The provider is a custom **`IUnityXRDisplay`** subsystem
+that drives the DisplayXR runtime directly (its own OpenXR loader/instance in native) and
+**does not enable Unity's OpenXR loader**. So the old hook-era caveat (pre-1.16.1 OpenXR
+silently ignoring `XR_RUNTIME_JSON` in editor play mode and falling back to the Mock Runtime
+→ `0x0` resolution) does not apply. Enable **DisplayXR** (not OpenXR) in XR Plug-in
+Management. The package's only XR dependency is `com.unity.xr.management`.
 
 ### Resolved: window-drag phase-snap (#61)
 

--- a/Editor/URP/com.displayxr.unity.urp.editor.asmdef
+++ b/Editor/URP/com.displayxr.unity.urp.editor.asmdef
@@ -5,7 +5,6 @@
         "com.displayxr.unity",
         "com.displayxr.unity.urp",
         "com.displayxr.unity.editor",
-        "Unity.XR.OpenXR",
         "Unity.RenderPipelines.Universal.Runtime",
         "Unity.RenderPipelines.Core.Runtime"
     ],

--- a/Editor/com.displayxr.unity.editor.asmdef
+++ b/Editor/com.displayxr.unity.editor.asmdef
@@ -3,7 +3,6 @@
   "rootNamespace": "DisplayXR.Editor",
   "references": [
     "com.displayxr.unity",
-    "Unity.XR.OpenXR",
     "Unity.XR.Management",
     "Unity.XR.Management.Editor"
   ],

--- a/Runtime/DisplayXRLocal2D.cs
+++ b/Runtime/DisplayXRLocal2D.cs
@@ -4,7 +4,6 @@
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
-using UnityEngine.XR.OpenXR;
 
 namespace DisplayXR
 {
@@ -123,18 +122,14 @@ namespace DisplayXR
             // doesn't support Local2D, stay inert (no RT, no submission) so the
             // rest of the scene renders normally.
             //
-            // Provider mode (#166): Unity's OpenXR loader isn't active, so
-            // OpenXRRuntime.IsExtensionEnabled is always false — gate on the provider
-            // instead (it enables XR_EXT_local_3d_zone on its own instance). Without
-            // this branch the component early-returns and the Canvas falls through to
-            // the main eye texture (the "bubble pollutes the 3D" symptom).
+            // The provider (the sole backend since #166) enables XR_EXT_local_3d_zone
+            // on its own OpenXR instance and is the only thing that submits the Local2D
+            // layer, so gate purely on the provider being active. When it isn't (edit
+            // mode, or XR not started) stay inert — no RT, no submission — so the rest
+            // of the scene renders normally.
             m_ProviderMode = DisplayXRProviderDriver.IsActive;
-            if (!m_ProviderMode && !OpenXRRuntime.IsExtensionEnabled("XR_EXT_local_3d_zone"))
-            {
-                Debug.LogWarning("[DisplayXR] Local2D: XR_EXT_local_3d_zone not enabled — " +
-                                 "bubble layer disabled (runtime lacks Local2D support).");
+            if (!m_ProviderMode)
                 return;
-            }
 
             m_Canvas = GetComponent<Canvas>();
             m_CanvasRect = m_Canvas.GetComponent<RectTransform>();

--- a/Runtime/DisplayXRNative.cs
+++ b/Runtime/DisplayXRNative.cs
@@ -96,18 +96,6 @@ namespace DisplayXR
         public static extern void displayxr_set_transparent_background(int enabled);
 
         /// <summary>
-        /// (avatar simple-window) Opt into binding the runtime to Unity's REAL
-        /// main HWND (no off-screen overlay, no DWM cloak, no off-screen move).
-        /// Click-through is region-based; decoration toggles via
-        /// displayxr_toggle_window_decoration. Must be called BEFORE
-        /// xrCreateSession — typically from
-        /// [RuntimeInitializeOnLoadMethod(SubsystemRegistration)], like
-        /// displayxr_set_transparent_background. Windows only.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_request_simple_window(int enabled);
-
-        /// <summary>
         /// (#34 / #131) Define the 3D canvas sub-rect within the window client
         /// area, in pixels. The runtime weaves the 3D into this rect; the rest
         /// of the window is the 2D surround region. Pass width==0 || height==0
@@ -405,8 +393,8 @@ namespace DisplayXR
         /// (avatar simple-window) Style Unity's real main HWND for avatar-style
         /// windowing: strip to borderless WS_POPUP, subclass for the borderless
         /// right-drag (#61-bracketed), and let the hit-mask path drive
-        /// SetWindowRgn on this HWND. enabled=0 restores Unity's styles. Pair
-        /// with displayxr_request_simple_window. Call after the session starts.
+        /// SetWindowRgn on this HWND. enabled=0 restores Unity's styles. Call
+        /// after the session starts.
         /// </summary>
         /// <param name="enabled">1 to enable, 0 to restore original styles.</param>
         /// <param name="topmost">1 to add WS_EX_TOPMOST while enabled.</param>

--- a/Runtime/DisplayXRTransparentOverlay.cs
+++ b/Runtime/DisplayXRTransparentOverlay.cs
@@ -260,28 +260,6 @@ namespace DisplayXR
 #endif
         }
 
-        /// <summary>
-        /// (avatar simple-window) Opt into binding the runtime to Unity's REAL
-        /// main HWND for the next OpenXR session — no off-screen overlay, no DWM
-        /// cloak, no off-screen move. MUST be called BEFORE the session is
-        /// created (from the SAME
-        /// [RuntimeInitializeOnLoadMethod(SubsystemRegistration)] bootstrap as
-        /// <see cref="RequestTransparentSession"/>). The component must also
-        /// have <see cref="useSimpleWindow"/> enabled so OnEnable styles the
-        /// real HWND; the two together pick the avatar-style window. Windows
-        /// only — inert elsewhere.
-        /// </summary>
-        public static void RequestSimpleWindow()
-        {
-#if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
-            // The hook-era pre-session request is a no-op under the provider (it does
-            // its own window binding); the OnEnable set_simple_window styling path
-            // (win32) still applies. Guard so a missing hook export can't throw.
-            try { DisplayXRNative.displayxr_request_simple_window(1); }
-            catch (System.EntryPointNotFoundException) { }
-#endif
-        }
-
         void OnEnable()
         {
             m_Camera = GetComponent<Camera>();
@@ -324,9 +302,10 @@ namespace DisplayXR
             m_SimpleWindow = useSimpleWindow;
             if (m_SimpleWindow)
             {
-                // Avatar-style: style Unity's REAL HWND borderless. The session
-                // must have bound the real HWND (RequestSimpleWindow() at
-                // SubsystemRegistration); if it didn't, this no-ops harmlessly.
+                // Avatar-style: style Unity's REAL HWND borderless. Dormant / not
+                // viable under the provider (see the useSimpleWindow tooltip) — the
+                // provider binds its own window; this no-ops harmlessly if the real
+                // HWND isn't the bound one.
                 DisplayXRNative.displayxr_set_simple_window(1, alwaysOnTop ? 1 : 0);
             }
             else

--- a/Runtime/URP/com.displayxr.unity.urp.asmdef
+++ b/Runtime/URP/com.displayxr.unity.urp.asmdef
@@ -3,7 +3,6 @@
     "rootNamespace": "DisplayXR.URP",
     "references": [
         "com.displayxr.unity",
-        "Unity.XR.OpenXR",
         "Unity.RenderPipelines.Universal.Runtime",
         "Unity.RenderPipelines.Core.Runtime"
     ],

--- a/Runtime/com.displayxr.unity.asmdef
+++ b/Runtime/com.displayxr.unity.asmdef
@@ -2,7 +2,6 @@
   "name": "com.displayxr.unity",
   "rootNamespace": "DisplayXR",
   "references": [
-    "Unity.XR.OpenXR",
     "Unity.XR.Management",
     "Unity.InputSystem"
   ],

--- a/native~/displayxr_exports.h
+++ b/native~/displayxr_exports.h
@@ -85,14 +85,6 @@ DISPLAYXR_EXPORT void displayxr_set_editor_mode(int enabled);
 /// the end of the struct and is harmlessly ignored.
 DISPLAYXR_EXPORT void displayxr_set_transparent_background(int enabled);
 
-/// Opt into avatar-style "simple window" mode (Windows). When enabled the
-/// plugin binds the runtime to Unity's REAL main HWND directly — no off-screen
-/// overlay, no DWM cloak, no off-screen move. Click-through is region-based
-/// (SetWindowRgn on Unity's HWND) and decoration toggles via
-/// displayxr_toggle_window_decoration. Call from C# at SubsystemRegistration
-/// (before xrCreateSession), like displayxr_set_transparent_background.
-DISPLAYXR_EXPORT void displayxr_request_simple_window(int enabled);
-
 /// (#131) Register a Unity RenderTexture (R8G8B8A8_UNORM) as the 2D surround
 /// source. The runtime fills the non-canvas region (outside the canvas sub-rect
 /// set via displayxr_set_canvas_rect) from this texture each frame, post-weave,
@@ -179,8 +171,6 @@ DISPLAYXR_EXPORT void displayxr_set_viewport_size(uint32_t width, uint32_t heigh
 DISPLAYXR_EXPORT void displayxr_set_viewport_size_native(uint32_t width, uint32_t height,
                                                          int32_t screen_x, int32_t screen_y);
 
-DISPLAYXR_EXPORT int displayxr_request_display_mode(int mode_3d);
-
 /// (#140 / #396 W6) Capture the runtime's composed multi-view atlas to a PNG via
 /// xrCaptureAtlasEXT (XR_EXT_atlas_capture). The runtime does the readback with
 /// the compositor's own atlas image and writes
@@ -260,9 +250,8 @@ DISPLAYXR_EXPORT void displayxr_set_transparent_overlay(int enabled,
 /// runtime composites into). Click-through is region-based (SetWindowRgn via
 /// the existing hit-mask path, retargeted to this HWND); a borderless
 /// right-drag moves the window (#61-bracketed). Decoration toggles via
-/// displayxr_toggle_window_decoration. Pair with displayxr_request_simple_window
-/// (which selects the real HWND at session create). Mutually exclusive with
-/// shell mode and the transparent overlay. enabled=0 restores Unity's styles.
+/// displayxr_toggle_window_decoration. Mutually exclusive with shell mode and
+/// the transparent overlay. enabled=0 restores Unity's styles.
 /// @param enabled  Non-zero to enable, zero to restore.
 /// @param topmost  Non-zero to add WS_EX_TOPMOST while enabled.
 DISPLAYXR_EXPORT void displayxr_set_simple_window(int enabled, int topmost);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "https://github.com/DisplayXR/displayxr-unity.git"
   },
   "dependencies": {
-    "com.unity.xr.openxr": "1.16.1",
     "com.unity.xr.management": "4.4.0"
   },
   "samples": [


### PR DESCRIPTION
Provider-only close-out of epic #166 — removes the last vestiges of Unity's OpenXR stack and the dead hook exports, so the reference code is unequivocal about what's live.

## Task 1 — drop the `com.unity.xr.openxr` dependency
- `DisplayXRLocal2D` was the last consumer via `OpenXRRuntime.IsExtensionEnabled(...)`, which its own comment noted is **always false** in provider-only mode. Now gates purely on `DisplayXRProviderDriver.IsActive` (behavior-identical — the provider enables `XR_EXT_local_3d_zone` on its own instance and is the only thing that submits the Local2D layer).
- Removed the `using UnityEngine.XR.OpenXR;` and the `Unity.XR.OpenXR` reference from all 4 asmdefs (Runtime/Editor + URP variants — none used OpenXR types).
- Removed `com.unity.xr.openxr` from `package.json`; only `com.unity.xr.management` remains.

## Task 2 — remove dead hook-era exports
- `displayxr_request_display_mode` — unused (superseded by `DisplayXRProvider.RequestRenderingMode`).
- `displayxr_request_simple_window` — the export died with `hooks.cpp`; the C# P/Invoke + `RequestSimpleWindow()` wrapped it in a `try/catch` that silently swallowed `EntryPointNotFound` (the same misleading no-op shape as the #166 canvas-rect bug). Removed the decl, the P/Invoke, and the method. The real `set_simple_window` styling export + `useSimpleWindow` field stay (dormant avatar path, unchanged).

## Verification
- Compile-clean on **both BiRP** (Runtime+Editor asmdefs) **and URP** (URP asmdefs) via junction builds — 0 CS errors.
- Native rebuild unchanged (removed decls were never compiled/exported) → no binary churn.

Net **+24/−71**. CLAUDE.md OpenXR-dependency section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)