### PR TITLE
chore: remove 9 dead hook-era exports (batch 2) (#166)

### DIFF
--- a/Runtime/DisplayXRNative.cs
+++ b/Runtime/DisplayXRNative.cs
@@ -24,22 +24,6 @@ namespace DisplayXR
         private const string LibName = "displayxr_unity";
 
         /// <summary>
-        /// Set stereo rig tunables from game thread.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_set_tunables(
-            float ipdFactor,
-            float parallaxFactor,
-            float perspectiveFactor,
-            float virtualDisplayHeight,
-            float invConvergenceDistance,
-            float fovOverride,
-            float nearZ,
-            float farZ,
-            int cameraCentric,
-            int clipAtDisplayPlane);
-
-        /// <summary>
         /// Get display info queried from runtime via XR_EXT_display_info.
         /// </summary>
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
@@ -63,23 +47,6 @@ namespace DisplayXR
             out float lx, out float ly, out float lz,
             out float rx, out float ry, out float rz,
             out int isTracked);
-
-        /// <summary>
-        /// Set scene transform (parent camera pose + zoom) applied before Kooima.
-        /// Chain: raw eyes → scene transform → tunables → Kooima.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_set_scene_transform(
-            float posX, float posY, float posZ,
-            float oriX, float oriY, float oriZ, float oriW,
-            float scaleX, float scaleY, float scaleZ,
-            int enabled);
-
-        /// <summary>
-        /// Set the window handle for session creation (HWND on Win32, NSView* on macOS).
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_set_window_handle(IntPtr handle);
 
         /// <summary>
         /// (runtime-pvt #191 / displayxr-unity #57) Request the runtime's
@@ -116,27 +83,6 @@ namespace DisplayXR
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int displayxr_get_canvas_rect_px(
             out int x, out int y, out uint width, out uint height);
-
-        /// <summary>
-        /// (XR_EXT_display_zones) Define the 3D-zone rect (client-window pixels,
-        /// top-left origin) the runtime frames the Kooima 3D into. The locate
-        /// hook chains an XrDisplayZoneEXT in front of the view-rig (zone-scoped
-        /// projection) and the xrEndFrame hook chains the same zone on each
-        /// projection layer (binding its views into the rect). width&lt;=0 ||
-        /// height&lt;=0 clears. Inert unless the runtime advertises
-        /// XR_EXT_display_zones and reports caps.supported. Mutually exclusive
-        /// with displayxr_set_canvas_rect (a zones frame makes the output rect
-        /// inert). Hooked path (built apps) only.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_set_3d_zone_rect(int x, int y, int width, int height);
-
-        /// <summary>
-        /// (XR_EXT_display_zones) Clear the 3D-zone rect (revert to full-window
-        /// framing). Hooked path (built apps) only.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_clear_3d_zone();
 
         /// <summary>
         /// (#131) Get the runtime's weave-target size = the bound HWND client
@@ -191,14 +137,6 @@ namespace DisplayXR
         public static extern void displayxr_macos_set_window_borderless(int enabled);
 
         /// <summary>
-        /// Hint the typed-swapchain substitution about the project color space.
-        /// 1 = Linear (UNORM_SRGB siblings); 0 = Gamma (UNORM siblings).
-        /// Must be called BEFORE Unity creates its OpenXR swapchains.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_set_use_srgb_swapchain(int enabled);
-
-        /// <summary>
         /// Check whether the plugin is running in shell/IPC mode.
         /// Detected via DISPLAYXR_WORKSPACE_SESSION=1 (legacy
         /// DISPLAYXR_SHELL_SESSION=1 is also honored) environment variable.
@@ -237,23 +175,6 @@ namespace DisplayXR
             out int buttons, out int mouseX, out int mouseY);
 
         /// <summary>
-        /// (#140 / #396 W6) Capture the runtime's composed multi-view atlas to a
-        /// PNG via xrCaptureAtlasEXT (XR_EXT_atlas_capture). The runtime does the
-        /// readback with the compositor's own atlas image and writes
-        /// "&lt;pathPrefix&gt;_atlas_&lt;viewCount&gt;_&lt;cols&gt;x&lt;rows&gt;.png"
-        /// (runtime owns the suffix; see DisplayXR/displayxr-runtime#425) — no
-        /// app-side AsyncGPUReadback or hidden-camera re-render. Non-blocking
-        /// (latches; PNG lands next composed frame).
-        /// </summary>
-        /// <param name="pathPrefix">Bare output path prefix (no layout tokens); the
-        /// runtime appends "_atlas_&lt;viewCount&gt;_&lt;cols&gt;x&lt;rows&gt;.png".</param>
-        /// <param name="stage">1 = projection-only, 0 = post-compose (includes chrome).</param>
-        /// <returns>1 on XR_SUCCEEDED, 0 if unresolved / no session / failed.</returns>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int displayxr_capture_atlas(
-            [MarshalAs(UnmanagedType.LPStr)] string pathPrefix, int stage);
-
-        /// <summary>
         /// Get the Kooima stereo view and projection matrices computed by the native library.
         /// These are the matched matrix pairs that should be applied directly, bypassing
         /// Unity's matrix reconstruction from (fov, position, orientation).
@@ -266,22 +187,6 @@ namespace DisplayXR
             [MarshalAs(UnmanagedType.LPArray, SizeConst = 16)] float[] rightView,
             [MarshalAs(UnmanagedType.LPArray, SizeConst = 16)] float[] rightProj,
             out int valid);
-
-        /// <summary>
-        /// Get readback pixel data from offscreen rendering.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_get_readback(
-            out IntPtr pixels,
-            out uint width,
-            out uint height,
-            out int ready);
-
-        /// <summary>
-        /// Kill xrPollEvent forwarding. Call before session/instance teardown.
-        /// </summary>
-        [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void displayxr_stop_polling();
 
         // ====================================================================
         // Window-space UI overlay (issue #67)

--- a/Runtime/Provider/DisplayXRProvider.cs
+++ b/Runtime/Provider/DisplayXRProvider.cs
@@ -114,9 +114,8 @@ namespace DisplayXR
 
         /// <summary>
         /// Set the single 3D-zone rect (client-window pixels) the runtime frames the
-        /// Kooima 3D into (#166 Phase B) — the provider analog of
-        /// <see cref="DisplayXRNative.displayxr_set_3d_zone_rect"/> on the hook path.
-        /// Seed early (SubsystemRegistration) so the swapchain is born zone-sized.
+        /// Kooima 3D into (#166 Phase B). Seed early (SubsystemRegistration) so the
+        /// swapchain is born zone-sized.
         /// width&lt;=0||height&lt;=0 clears. Safe to call whether or not the provider is active.
         /// </summary>
         public static void SetZoneRect(int x, int y, int width, int height) =>

--- a/Runtime/Provider/DisplayXRProviderNative.cs
+++ b/Runtime/Provider/DisplayXRProviderNative.cs
@@ -160,8 +160,8 @@ namespace DisplayXR
             uint zone, out int x, out int y, out int w, out int h);
 
         /// <summary>
-        /// Push the stereo rig tunables (mirrors displayxr_set_tunables, minus the
-        /// clipAtDisplayPlane flag the rig descriptor doesn't carry). Scale-as-zoom
+        /// Push the stereo rig tunables to the provider (minus the clipAtDisplayPlane
+        /// flag the rig descriptor doesn't carry). Scale-as-zoom
         /// must be folded into virtualDisplayHeight / invConvergenceDistance by the
         /// caller (the native side mirrors the standalone and ignores scale).
         /// </summary>

--- a/native~/displayxr_exports.h
+++ b/native~/displayxr_exports.h
@@ -26,17 +26,6 @@ void displayxr_log(const char *fmt, ...);
 
 // --- P/Invoke exports for C# ---
 
-DISPLAYXR_EXPORT void displayxr_set_tunables(float ipd_factor,
-                                           float parallax_factor,
-                                           float perspective_factor,
-                                           float virtual_display_height,
-                                           float inv_convergence_distance,
-                                           float fov_override,
-                                           float near_z,
-                                           float far_z,
-                                           int camera_centric,
-                                           int clip_at_display_plane);
-
 DISPLAYXR_EXPORT void displayxr_get_display_info(float *display_width_m,
                                                float *display_height_m,
                                                uint32_t *pixel_width,
@@ -55,20 +44,6 @@ DISPLAYXR_EXPORT void displayxr_get_eye_positions(float *lx,
                                                 float *ry,
                                                 float *rz,
                                                 int *is_tracked);
-
-DISPLAYXR_EXPORT void displayxr_set_scene_transform(float pos_x,
-                                                   float pos_y,
-                                                   float pos_z,
-                                                   float ori_x,
-                                                   float ori_y,
-                                                   float ori_z,
-                                                   float ori_w,
-                                                   float scale_x,
-                                                   float scale_y,
-                                                   float scale_z,
-                                                   int enabled);
-
-DISPLAYXR_EXPORT void displayxr_set_window_handle(void *handle);
 
 DISPLAYXR_EXPORT void displayxr_set_editor_mode(int enabled);
 
@@ -129,14 +104,6 @@ DISPLAYXR_EXPORT void displayxr_macos_end_window_drag(void);
 /// Save/restore is symmetric; set(0) restores. Idempotent.
 DISPLAYXR_EXPORT void displayxr_macos_set_window_borderless(int enabled);
 
-/// Hint the typed-swapchain substitution about Unity's project color space.
-/// Must be called BEFORE Unity creates its OpenXR swapchains (i.e. from the
-/// OpenXR feature's OnInstanceCreate).
-///   1 = Linear color space → UNORM_SRGB typed siblings.
-///   0 = Gamma color space  → UNORM typed siblings (no double gamma encoding).
-/// Default is 1 (sRGB) for backward compatibility.
-DISPLAYXR_EXPORT void displayxr_set_use_srgb_swapchain(int enabled);
-
 /// Check whether the plugin is running in shell/IPC mode.
 /// Detected via DISPLAYXR_WORKSPACE_SESSION=1 (legacy DISPLAYXR_SHELL_SESSION=1
 /// is also honored) environment variable.
@@ -158,27 +125,11 @@ DISPLAYXR_EXPORT void displayxr_set_viewport_size(uint32_t width, uint32_t heigh
 DISPLAYXR_EXPORT void displayxr_set_viewport_size_native(uint32_t width, uint32_t height,
                                                          int32_t screen_x, int32_t screen_y);
 
-/// (#140 / #396 W6) Capture the runtime's composed multi-view atlas to a PNG via
-/// xrCaptureAtlasEXT (XR_EXT_atlas_capture). The runtime does the readback with
-/// the compositor's own atlas image and writes
-/// "<path_prefix>_atlas_<viewCount>_<cols>x<rows>.png" (it owns the suffix —
-/// DisplayXR/displayxr-runtime#425) — the app passes a bare prefix and no longer
-/// needs an AsyncGPUReadback or hidden-camera re-render. Non-blocking
-/// (latches; PNG lands next composed frame). @param stage 1 = projection-only,
-/// 0 = post-compose (includes chrome/quad layers). Returns 1 on XR_SUCCEEDED, 0
-/// if the extension is unresolved, there is no live session, or the call failed.
-DISPLAYXR_EXPORT int displayxr_capture_atlas(const char *path_prefix, int stage);
-
 DISPLAYXR_EXPORT void displayxr_get_stereo_matrices(float *left_view,
                                                    float *left_proj,
                                                    float *right_view,
                                                    float *right_proj,
                                                    int *valid);
-
-DISPLAYXR_EXPORT void displayxr_get_readback(uint8_t **pixels,
-                                           uint32_t *width,
-                                           uint32_t *height,
-                                           int *ready);
 
 DISPLAYXR_EXPORT void *displayxr_create_shared_texture(uint32_t width, uint32_t height);
 
@@ -200,24 +151,6 @@ DISPLAYXR_EXPORT void displayxr_set_canvas_rect(
 /// into the same sub-rect the runtime weaves the 3D into. Out params may be NULL.
 DISPLAYXR_EXPORT int displayxr_get_canvas_rect_px(
     int32_t *x, int32_t *y, uint32_t *w, uint32_t *h);
-
-/// XR_EXT_display_zones: define the 3D-zone rect (client-window pixels, top-left
-/// origin) the runtime frames the Kooima 3D into. The locate hook chains an
-/// XrDisplayZoneEXT in front of the view-rig (zone-scoped projection) and the
-/// xrEndFrame hook chains the same zone on each projection layer (binding its
-/// views into the rect). w<=0 || h<=0 clears. Inert unless the runtime advertises
-/// XR_EXT_display_zones and reports caps.supported. Mutually exclusive with the
-/// canvas-rect/surround path (a zones frame makes the output rect inert). Hooked
-/// path (built apps) only.
-DISPLAYXR_EXPORT void displayxr_set_3d_zone_rect(
-    int32_t x, int32_t y, int32_t w, int32_t h);
-
-/// XR_EXT_display_zones: clear the 3D-zone rect (revert to full-window framing).
-DISPLAYXR_EXPORT void displayxr_clear_3d_zone(void);
-
-/// Kill xrPollEvent forwarding immediately. Call from C# before session/instance
-/// teardown to prevent use-after-free when the runtime is unloaded.
-DISPLAYXR_EXPORT void displayxr_stop_polling(void);
 
 #ifdef _WIN32
 /// (issue #57) Toggle transparent overlay mode on the parent (Unity top-

--- a/native~/displayxr_xrprovider/displayxr_provider_session.cpp
+++ b/native~/displayxr_xrprovider/displayxr_provider_session.cpp
@@ -2883,9 +2883,9 @@ int dxr_prov_set_eye_tracking_mode(int manual)
 
 // ---- Atlas capture (XR_EXT_atlas_capture, #140) -----------------------------
 
-// Provider-mode analog of displayxr_capture_atlas (hook path): hand the runtime a
-// path prefix + stage; it reads back its own compositor atlas and writes the PNG on
-// the next composed frame. Non-blocking — XR_SUCCESS means accepted, not on-disk.
+// Atlas capture: hand the runtime a path prefix + stage; it reads back its own
+// compositor atlas and writes the PNG on the next composed frame. Non-blocking —
+// XR_SUCCESS means accepted, not on-disk.
 int dxr_prov_capture_atlas(const char *path_prefix, int stage)
 {
 	if (s_ps.pfn_capture_atlas == NULL || s_ps.session == XR_NULL_HANDLE) {


### PR DESCRIPTION
Second dead-export pass. All 9 were defined **only in the deleted `hooks.cpp`** — verified not in the shipping DLL, not in `displayxr_macos.mm`, not in any compiled TU — so their `exports.h` decls + C# `[DllImport]`s were dead.

**Removed:**
| Export | Status |
|---|---|
| `displayxr_set_tunables` | provider twin `dxr_prov_set_tunables` |
| `displayxr_capture_atlas` | provider twin `dxr_prov_capture_atlas` |
| `displayxr_set_3d_zone_rect` | provider `DisplayXRProvider.SetZoneRect` |
| `displayxr_clear_3d_zone` | provider zone path |
| `displayxr_set_scene_transform` | unused under provider |
| `displayxr_set_window_handle` | unused (provider binds its own window) |
| `displayxr_set_use_srgb_swapchain` | unused (provider does sRGB→UNORM itself) |
| `displayxr_get_readback` | unused |
| `displayxr_stop_polling` | unused |

None called by the plugin. `set_3d_zone_rect`/`clear_3d_zone` were called try-guarded by the `-transparent` demo's `TigerSpeechBubble` next to the live `DisplayXRProvider.SetZoneRect` — those dead calls are dropped in that repo (separate commit). Also fixed a dangling `<see cref>` + two stale comments.

**Verified:** compile-clean (0 CS errors) with the plugin junctioned into the URP `-transparent` app (exercises `TigerSpeechBubble` + the zone exports). No binary change (removed decls were never compiled/exported).

Remaining hook-era cleanup: the compiled-but-inert hook graphics-backend TUs + `s_real_*` (**task 3**, its own session).

Net **+7/−170**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)