### PR TITLE
feat: closing the Play-Mode preview window stops Play Mode (plugin-wide)

### DIFF
--- a/Editor/DisplayXRPreviewClose.cs
+++ b/Editor/DisplayXRPreviewClose.cs
@@ -1,0 +1,59 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using UnityEditor;
+using UnityEngine;
+using DisplayXR;
+
+namespace DisplayXR.Editor
+{
+    /// <summary>
+    /// Closing the provider's dedicated Play-Mode preview window (its X button or
+    /// Alt+F4) stops Play Mode — a property of the plugin, so no project has to wire
+    /// it. The preview window is the plugin's own window, so its close obviously
+    /// means "stop the preview."
+    ///
+    /// The native dedicated-window WndProc (displayxr_win32.c `dedicated_wnd_proc`
+    /// WM_CLOSE) swallows the close — it must NOT DestroyWindow the live weave
+    /// target — and raises a close-request flag. Here we poll that flag each editor
+    /// tick during Play Mode and exit Play Mode, which tears the window down cleanly
+    /// via the subsystem's LifecycleStop.
+    ///
+    /// Built players keep app-owned quit policy: the app polls the SAME flag
+    /// (`displayxr_consume_overlay_close_request`) and decides `Application.Quit`.
+    /// App pollers early-return in the editor (`Application.isEditor`), so this
+    /// editor-only poll is the sole consumer in Play Mode — no double-consume race.
+    /// </summary>
+    [InitializeOnLoad]
+    internal static class DisplayXRPreviewClose
+    {
+        static DisplayXRPreviewClose()
+        {
+            EditorApplication.update += Poll;
+        }
+
+        static void Poll()
+        {
+            // Only while the provider is actually driving a Play-Mode preview.
+            if (!EditorApplication.isPlaying) return;
+            if (!DisplayXRProviderDriver.IsActive) return;
+
+            int closed;
+            try
+            {
+                // Consumes (reads + clears) the native close-request flag.
+                closed = DisplayXRNative.displayxr_consume_overlay_close_request();
+            }
+            catch (System.EntryPointNotFoundException)
+            {
+                return; // older native plugin without the export — nothing to do
+            }
+
+            if (closed != 0)
+            {
+                Debug.Log("[DisplayXR] Preview window closed — stopping Play Mode.");
+                EditorApplication.isPlaying = false;
+            }
+        }
+    }
+}

--- a/Editor/DisplayXRPreviewClose.cs.meta
+++ b/Editor/DisplayXRPreviewClose.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4df56cca1e35473688d572acce37318b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
Makes **closing the provider's Play-Mode preview window stop Play Mode** a property of the plugin — any project gets it, no app code.

The editor preview window is the plugin's own window; the native `dedicated_wnd_proc` already swallows `WM_CLOSE` and raises a close-request flag, but nothing consumed it in the editor (only apps do, and only in built players). This adds the editor-side consumer: an `[InitializeOnLoad]` poll of `displayxr_consume_overlay_close_request()` that sets `EditorApplication.isPlaying = false` while the provider drives a Play-Mode preview.

Built players unchanged (app-owned `Application.Quit` policy; app pollers `Application.isEditor`-early-return, so no double-consume race). C#/editor-only, no native change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)