### PR TITLE
Release v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.displayxr.unity",
   "displayName": "DisplayXR",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "unity": "2022.3",
   "description": "Unity plugin for DisplayXR OpenXR runtime enabling stereo rendering on 3D light field displays. Provides display-centric and camera-centric stereo rig authoring, Kooima asymmetric frustum projection, 2D UI overlay support, and in-editor preview.",
   "keywords": [


### PR DESCRIPTION
Bump package.json to 2.2.0 for the v2.2.0 release. CHANGELOG entry already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)