### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the DisplayXR Unity plugin will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-07-05
+
+### Fixed
+- Scene-view eye-position gizmos were frozen at nominal under the provider; the provider now
+  publishes live raw eye positions to shared state so the gizmo tracks head movement (#189).
+
 ## [2.2.0] - 2026-07-05
 
 **URP off-axis simplification + HDRP support, plus the two already-merged cleanups (#185 meta hygiene, #186 preview-close-stops-play).** The provider now hands Unity a **full per-eye projection matrix** instead of half-angle FOVs, so URP and HDRP both consume the off-center Kooima frustum correctly with no per-pipeline fix. The URP `KooimaProjectionFixFeature` is removed. No app-facing API change; the projection change is internal to the native provider. Hardware-verified on RTX 3080 across BiRP, URP (2D-UI + transparent w/ foreground clip + click-through), and HDRP (#22, #166 M3).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.displayxr.unity",
   "displayName": "DisplayXR",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "unity": "2022.3",
   "description": "Unity plugin for DisplayXR OpenXR runtime enabling stereo rendering on 3D light field displays. Provides display-centric and camera-centric stereo rig authoring, Kooima asymmetric frustum projection, 2D UI overlay support, and in-editor preview.",
   "keywords": [


### PR DESCRIPTION
Release v2.2.1 — provider publishes live eye positions so the Scene-view eye gizmo tracks the head (#189).