### PR TITLE
feat!: rename DisplayXR extensions XR_EXT_* → XR_DXR_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ The custom **`IUnityXRDisplay` display provider becomes the shipping rendering p
 - **Live tile reallocation** (#172) — zone-rect tile realloc for primary + extra zones and realloc on window resize.
 - **App-owned / dedicated / self-host weave targets** (#173) — provider defaults to an app-owned window; self-host behind `DISPLAYXR_PROV_SELFHOST`; a dedicated movable weave window for in-editor Play Mode.
 - **Provider runs in Play Mode** (#171) — provider-aware editor status; `xreditorsubsystem` keyword so the display subsystem is discoverable in-editor.
-- **App-facing atlas screenshot** (`I` key) via `XR_EXT_atlas_capture` — screenshot parity with the hook path (#140).
+- **App-facing atlas screenshot** (`I` key) via `XR_DXR_atlas_capture` — screenshot parity with the hook path (#140).
 - **Shared smooth 2D↔3D mode-switch sequencer** (`DisplayXRModeSwitch`) (#172).
 - **Window-space UI (HUD) composition layer** under the provider (#166).
 - **DLL code-signing** in the `.tgz` and `upm` branch (#167).
@@ -132,7 +132,7 @@ The custom **`IUnityXRDisplay` display provider becomes the shipping rendering p
 ## [1.21.0] - 2026-06-19
 
 ### Added
-- **`XR_EXT_display_zones` port — 3D display zones**: the plugin renders into runtime-advertised display zones, sizing the 3D eye render to `xrGetDisplayZoneRecommendedViewSize` (via `renderViewportScale`) so the zone-sized stereo render no longer leaks a band under zoom.
+- **`XR_DXR_display_zones` port — 3D display zones**: the plugin renders into runtime-advertised display zones, sizing the 3D eye render to `xrGetDisplayZoneRecommendedViewSize` (via `renderViewportScale`) so the zone-sized stereo render no longer leaks a band under zoom.
 - **Local2D composition layer (#439/#491)** — modern 2D-over-3D path: a `DisplayXRLocal2D` component composites a 2D layer over the 3D scene.
 - **Avatar-style windowing primitives** on the transparent overlay: native toggle-decoration (B), keyboard window resize, drag-move, get/set overlay window position (for app-side persistence), and consume-overlay-close-request (close-to-quit). Window-chrome UI policy moved out of the plugin into the app.
 
@@ -144,7 +144,7 @@ The custom **`IUnityXRDisplay` display provider becomes the shipping rendering p
 - **Window-chrome UI policy moved out of the plugin into the app** — the plugin exposes native windowing primitives (decoration toggle, resize, position get/set, close-request) and the app owns the UX policy.
 
 ### Fixed
-- **`XR_EXT_view_rig` SPEC_VERSION 3 compatibility** (native): the runtime advanced the extension to SPEC 3, which adds a trailing `metersToVirtual` float to `XrCameraRigEXT`. The plugin shipped the SPEC 2 struct, so against a SPEC 3 runtime the runtime read that field past the end of the plugin's struct for **camera-centric** rigs (`DisplayXRCamera`) — undefined value (best case 0 → runtime's pre-v3 default of 1.0, worst case garbage → wrong world scale). The plugin now declares SPEC 3 and writes `metersToVirtual = 1.0f` (scene scale is already folded into `convergenceDiopters`, so this exactly preserves pre-v3 behavior). **Display-centric rigs (`DisplayXRDisplay` → `XrDisplayRigEXT`) were unaffected** — that struct is byte-identical across SPEC 2/3 — so the transparent/2D-UI display-centric demos already worked on a SPEC 3 runtime; this fixes the camera-centric path. Detection remains name-based (no version gate).
+- **`XR_DXR_view_rig` SPEC_VERSION 3 compatibility** (native): the runtime advanced the extension to SPEC 3, which adds a trailing `metersToVirtual` float to `XrCameraRigDXR`. The plugin shipped the SPEC 2 struct, so against a SPEC 3 runtime the runtime read that field past the end of the plugin's struct for **camera-centric** rigs (`DisplayXRCamera`) — undefined value (best case 0 → runtime's pre-v3 default of 1.0, worst case garbage → wrong world scale). The plugin now declares SPEC 3 and writes `metersToVirtual = 1.0f` (scene scale is already folded into `convergenceDiopters`, so this exactly preserves pre-v3 behavior). **Display-centric rigs (`DisplayXRDisplay` → `XrDisplayRigDXR`) were unaffected** — that struct is byte-identical across SPEC 2/3 — so the transparent/2D-UI display-centric demos already worked on a SPEC 3 runtime; this fixes the camera-centric path. Detection remains name-based (no version gate).
 
 ## [1.20.0] - 2026-06-15
 
@@ -162,8 +162,8 @@ The custom **`IUnityXRDisplay` display provider becomes the shipping rendering p
 ## [1.19.0] - 2026-06-09
 
 ### Changed
-- **Kooima projection is now owned by the DisplayXR runtime via `XR_EXT_view_rig`** (`DisplayXR/displayxr-runtime#396` W7, ADR-024). The plugin no longer computes Kooima: it chains an `XrDisplayRigEXT`/`XrCameraRigEXT` descriptor (scene transform + the handful of tunables) onto `xrLocateViews` and consumes render-ready `XrView{pose, fov}` — on **both** the built-app hook path and the standalone editor-preview session. The former vendored/`displayxr::math` display3d/camera3d Kooima math is removed (~500 lines, plus `displayxr_kooima.{cpp,h}`; the `displayxr::math` link is dropped). The P/Invoke surface and C# API are unchanged.
-  - **⚠️ Requires a DisplayXR runtime that advertises `XR_EXT_view_rig` (SPEC_VERSION 2) _and_ the #396 W7 window-metrics fixes — both ship in runtime `v1.16.0` (bundle `0.17.0`).** Against an older runtime the plugin emits a one-shot WARN and passes the raw views through, which renders **no stereo**. Update the runtime to `0.17.0`+ before installing this plugin version.
+- **Kooima projection is now owned by the DisplayXR runtime via `XR_DXR_view_rig`** (`DisplayXR/displayxr-runtime#396` W7, ADR-024). The plugin no longer computes Kooima: it chains an `XrDisplayRigDXR`/`XrCameraRigDXR` descriptor (scene transform + the handful of tunables) onto `xrLocateViews` and consumes render-ready `XrView{pose, fov}` — on **both** the built-app hook path and the standalone editor-preview session. The former vendored/`displayxr::math` display3d/camera3d Kooima math is removed (~500 lines, plus `displayxr_kooima.{cpp,h}`; the `displayxr::math` link is dropped). The P/Invoke surface and C# API are unchanged.
+  - **⚠️ Requires a DisplayXR runtime that advertises `XR_DXR_view_rig` (SPEC_VERSION 2) _and_ the #396 W7 window-metrics fixes — both ship in runtime `v1.16.0` (bundle `0.17.0`).** Against an older runtime the plugin emits a one-shot WARN and passes the raw views through, which renders **no stereo**. Update the runtime to `0.17.0`+ before installing this plugin version.
 - The BiRP per-eye projection override (`SetStereoProjectionMatrix`) is **retained and always applied**. A probe showed BiRP consumes `views[i].fov` directly when the window is centered, but for **window-relative off-center** windows the rig fov is a sheared off-axis frustum that Unity's XR fov→projection path mishandles (over-separates the eyes) — so the plugin keeps building the projection itself. BiRP also keeps the `SetStereoViewMatrix` + `FlipViewZ` handedness shim.
 - Foreground-only clip (#57 family) is preserved under the rig path: the rig fov is clip-independent, so the per-view far plane is rebuilt app-side (display rig = eye→display-plane distance; camera rig = convergence distance) — BiRP via `SetStereoProjectionMatrix`, **URP via `Camera.farClipPlane`** (URP ignores `SetStereoProjectionMatrix`).
 
@@ -197,12 +197,12 @@ The custom **`IUnityXRDisplay` display provider becomes the shipping rendering p
 ## [1.16.0] - 2026-06-05
 
 ### Changed
-- Atlas screenshot filenames adopt the runtime-owned suffix `<stem>-<N>_atlas_<viewCount>_<cols>x<rows>.png` (XR_EXT_atlas_capture spec v2, `DisplayXR/displayxr-runtime#425`). The live `xrCaptureAtlasEXT` path now passes a bare `<stem>-<N>` prefix (no pre-baked `_<cols>x<rows>`) and lets the runtime own the `_atlas_…` tokens, so the final name no longer duplicates the layout (`..._2x1_atlas_2_2x1.png`). The editor-preview (app-side) path writes the same name so both share one sequence counter.
+- Atlas screenshot filenames adopt the runtime-owned suffix `<stem>-<N>_atlas_<viewCount>_<cols>x<rows>.png` (XR_DXR_atlas_capture spec v2, `DisplayXR/displayxr-runtime#425`). The live `xrCaptureAtlasDXR` path now passes a bare `<stem>-<N>` prefix (no pre-baked `_<cols>x<rows>`) and lets the runtime own the `_atlas_…` tokens, so the final name no longer duplicates the layout (`..._2x1_atlas_2_2x1.png`). The editor-preview (app-side) path writes the same name so both share one sequence counter.
 
 ## [1.15.0] - 2026-06-04
 
 ### Changed
-- **The 'I'-key atlas screenshot is now runtime-owned via `xrCaptureAtlasEXT`** (XR_EXT_atlas_capture, spec v1) for live OpenXR sessions (#140, #396 W6). A live session hands the runtime a path prefix; the runtime reads back its own composited atlas and writes `<prefix>_atlas.png`. The plugin no longer does an app-side `AsyncGPUReadback` or a hidden-camera Kooima re-render on the live path. New public API `DisplayXRFeature.CaptureAtlas(pathPrefix, projectionOnly)`. **Requires a DisplayXR runtime that advertises `XR_EXT_atlas_capture`** — against older runtimes the capture logs `…unavailable` and is a no-op (no crash). The editor-preview (standalone-session) path is unchanged: it still encodes the atlas RT app-side, since there is no runtime OpenXR session in pure-editor preview.
+- **The 'I'-key atlas screenshot is now runtime-owned via `xrCaptureAtlasDXR`** (XR_DXR_atlas_capture, spec v1) for live OpenXR sessions (#140, #396 W6). A live session hands the runtime a path prefix; the runtime reads back its own composited atlas and writes `<prefix>_atlas.png`. The plugin no longer does an app-side `AsyncGPUReadback` or a hidden-camera Kooima re-render on the live path. New public API `DisplayXRFeature.CaptureAtlas(pathPrefix, projectionOnly)`. **Requires a DisplayXR runtime that advertises `XR_DXR_atlas_capture`** — against older runtimes the capture logs `…unavailable` and is a no-op (no crash). The editor-preview (standalone-session) path is unchanged: it still encodes the atlas RT app-side, since there is no runtime OpenXR session in pure-editor preview.
 
 ### Fixed
 - Live-path screenshot no longer captures the white feedback flash. The flash draws into the same eye buffers the runtime composites for the capture, so arming it immediately whited out the saved atlas; the flash is now deferred a few frames so the runtime grabs the clean atlas first (#140).
@@ -414,7 +414,7 @@ The custom **`IUnityXRDisplay` display provider becomes the shipping rendering p
 
 ### Added
 - **macOS transparent overlay — Phase 1 visual transparency (`#85`)** —
-  `XR_EXT_cocoa_window_binding` is wired through with the
+  `XR_DXR_cocoa_window_binding` is wired through with the
   `transparentBackgroundEnabled` flag, and Unity's `NSWindow` is configured
   for per-pixel alpha so the runtime can render into a transparent surface
   on macOS. Mirrors the Windows transparent overlay capability (#57) at the
@@ -692,7 +692,7 @@ The custom **`IUnityXRDisplay` display provider becomes the shipping rendering p
 ## [1.2.6] - 2026-05-06
 
 ### Added
-- Submit `DisplayXRWindowSpaceUI` as `XrCompositionLayerWindowSpaceEXT` so
+- Submit `DisplayXRWindowSpaceUI` as `XrCompositionLayerWindowSpaceDXR` so
   2D UI canvases composite as a stereo overlay layer with proper disparity
   on the DisplayXR runtime. (#67)
 
@@ -1020,7 +1020,7 @@ documentation structure with ADRs.
 
 ### Fixed
 - Fix canvas rect DPI: send logical pixels on Windows, backing pixels on macOS (#41)
-  - `xrSetSharedTextureOutputRectEXT` takes HWND client-area pixels per spec
+  - `xrSetSharedTextureOutputRectDXR` takes HWND client-area pixels per spec
   - On DPI-aware Windows (Unity 6), `Screen.width` is already logical pixels
   - On macOS, `Screen.width` is in points — multiply by backing scale factor
 
@@ -1172,7 +1172,7 @@ documentation structure with ADRs.
 - 2D UI overlay component (`DisplayXRWindowSpaceUI`) for HUDs and menus
 - Standalone editor preview window with camera selector, rendering mode controls, and zero-copy GPU texture sharing (IOSurface/DXGI)
 - Game View overlay (`DisplayXRGameViewOverlay`) for Play Mode shared texture output
-- Canvas-aware shared texture cropping via `xrSetSharedTextureOutputRectEXT`
+- Canvas-aware shared texture cropping via `xrSetSharedTextureOutputRectDXR`
 - Custom inspectors for camera-centric and display-centric modes
 - Project Settings page showing runtime status and display info
 - Native plugin source (`native~/`) with independent CMake build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,15 +43,15 @@ Raw CMake (`cd native~ && mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE
 
 1. **Runtime (C#)** — the **`IUnityXRDisplay` display provider** (`Runtime/Provider/`): `DisplayXRDisplayLoader` is the XR-Management loader/subsystem, `DisplayXRProvider` is the app-facing facade, `DisplayXRProviderDriver` runs the per-frame pump. `DisplayXRCamera.cs` and `DisplayXRDisplay.cs` are the two stereo rig modes; `DisplayXRRigManager.cs` coordinates multi-camera scenes.
 2. **Editor (C#)** — Custom inspectors and the settings/XR-Management page. (No standalone preview system — Play Mode runs the provider directly.)
-3. **Native (C/C++)** — the display provider (`native~/displayxr_xrprovider/`): opens the OpenXR session on **Unity's D3D12 device**, creates an `arraySize=2` swapchain (SPI or MultiPass), chains the runtime's view-rig descriptor (`XR_EXT_view_rig`) onto `xrLocateViews` and consumes render-ready `XrView{pose, fov}` — the runtime owns the Kooima math — and submits via `xrEndFrame`. The win32 overlay, wsui composition layer, and Local2D paths survive alongside it; thread-safe shared state. The SA render-to-atlas core (`displayxr_standalone*`) is kept on disk but **not compiled** (dormant), reserved as the seed for a future many-view "quilt" render path (see `docs~/adr/ADR-007-render-path-by-view-count.md`).
+3. **Native (C/C++)** — the display provider (`native~/displayxr_xrprovider/`): opens the OpenXR session on **Unity's D3D12 device**, creates an `arraySize=2` swapchain (SPI or MultiPass), chains the runtime's view-rig descriptor (`XR_DXR_view_rig`) onto `xrLocateViews` and consumes render-ready `XrView{pose, fov}` — the runtime owns the Kooima math — and submits via `xrEndFrame`. The win32 overlay, wsui composition layer, and Local2D paths survive alongside it; thread-safe shared state. The SA render-to-atlas core (`displayxr_standalone*`) is kept on disk but **not compiled** (dormant), reserved as the seed for a future many-view "quilt" render path (see `docs~/adr/ADR-007-render-path-by-view-count.md`).
 
 ### Key Features
 
 - **Two stereo rig modes**: Camera-centric (`DisplayXRCamera` — inherits camera FOV, inv. convergence distance tunable) and display-centric (`DisplayXRDisplay` — physical display geometry, virtual display height, scale-as-zoom)
 - **Multi-camera support**: Multiple rigs coexist in one scene; `DisplayXRRigManager` coordinates which rig is active (see below)
 - **Play Mode == built app**: the `IUnityXRDisplay` provider runs identically in-editor and in a built player. Pressing Play *is* the preview — there is no separate preview window.
-- **2D UI overlay**: Canvas → `XrCompositionLayerWindowSpaceEXT` with stereo disparity
-- **Runtime-owned Kooima math (`XR_EXT_view_rig`, #396 W7)**: the plugin no longer computes Kooima. It chains an `XrDisplayRigEXT`/`XrCameraRigEXT` descriptor (the handful of tunables) onto `xrLocateViews` and consumes render-ready `XrView{pose, fov}` in the provider's per-frame pump (Play Mode and built player alike). **This requires a runtime that advertises `XR_EXT_view_rig` (SPEC_VERSION 2)**; against an older runtime the plugin emits a one-shot WARN and passes raw views through (no stereo). The former vendored/`displayxr::math` display3d/camera3d math is gone (do not re-add — see the `no-vendored-math` drift guard).
+- **2D UI overlay**: Canvas → `XrCompositionLayerWindowSpaceDXR` with stereo disparity
+- **Runtime-owned Kooima math (`XR_DXR_view_rig`, #396 W7)**: the plugin no longer computes Kooima. It chains an `XrDisplayRigDXR`/`XrCameraRigDXR` descriptor (the handful of tunables) onto `xrLocateViews` and consumes render-ready `XrView{pose, fov}` in the provider's per-frame pump (Play Mode and built player alike). **This requires a runtime that advertises `XR_DXR_view_rig` (SPEC_VERSION 2)**; against an older runtime the plugin emits a one-shot WARN and passes raw views through (no stereo). The former vendored/`displayxr::math` display3d/camera3d math is gone (do not re-add — see the `no-vendored-math` drift guard).
 
 ### Render Pipeline Support (BiRP / URP / HDRP)
 
@@ -149,7 +149,7 @@ Scenes can contain multiple cameras with different rig types (display-centric, c
 
 ### OpenXR path: the display provider
 
-The plugin drives OpenXR through the custom `IUnityXRDisplay` provider (`native~/displayxr_xrprovider/`) — it is the **sole** backend. The provider opens the session on Unity's D3D12 device, drives an `arraySize=2` swapchain (SPI/MultiPass), chains `XR_EXT_view_rig` onto `xrLocateViews` for runtime-owned Kooima, downgrades sRGB→UNORM swapchains in Gamma-space projects (so output isn't double-gamma-encoded), and submits overlay/wsui composition layers via `xrEndFrame`.
+The plugin drives OpenXR through the custom `IUnityXRDisplay` provider (`native~/displayxr_xrprovider/`) — it is the **sole** backend. The provider opens the session on Unity's D3D12 device, drives an `arraySize=2` swapchain (SPI/MultiPass), chains `XR_DXR_view_rig` onto `xrLocateViews` for runtime-owned Kooima, downgrades sRGB→UNORM swapchains in Gamma-space projects (so output isn't double-gamma-encoded), and submits overlay/wsui composition layers via `xrEndFrame`.
 
 > **The legacy OpenXR API-layer hook (`DisplayXRFeature` + `displayxr_hooks.cpp`) and the standalone (SA) editor-preview session/window were hard-removed in #166.** The provider replaced them. See `docs~/architecture/xr-display-provider.md`. Renamed native headers: `displayxr_hooks.h`→`displayxr_exports.h`, `displayxr_hooks_internal.h`→`displayxr_backend.h`; re-homed glue lives in `displayxr_native_shared.cpp`.
 
@@ -315,7 +315,7 @@ now archived and redirect here.)
 | `samples/birp-multipass` | Baseline rendering / stereo correctness (**BiRP**, multi-pass) | Plain cube + camera-centric and display-centric rigs |
 | `samples/urp-singlepass-ui` | 2D UI window-space composition layer (**URP**, single-pass) | Tuning panel built from `DisplayXRWindowSpaceUI` |
 | `samples/hdrp-singlepass-ui` | Off-axis correctness on **HDRP** (single-pass) | Textured crate; HDRP consumes the provider's projection matrix natively (no fix feature) |
-| `samples/desktop-avatar` | Desktop avatar showcase (**URP**): alpha-native transparency, click-through, per-eye foreground clip, `XR_EXT_display_zones` + Local2D bubble | Tiger FBX (Git LFS), foreground-only render |
+| `samples/desktop-avatar` | Desktop avatar showcase (**URP**): alpha-native transparency, click-through, per-eye foreground clip, `XR_DXR_display_zones` + Local2D bubble | Tiger FBX (Git LFS), foreground-only render |
 
 All pin the plugin via `https://github.com/DisplayXR/displayxr-unity.git#upm/vX.Y.Z`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for your interest in the DisplayXR Unity plugin.
 
 ## What Lives Where
 
-This repo contains the Unity plugin only — the OpenXR runtime, native compositors, and extension headers are in [`displayxr-runtime`](https://github.com/DisplayXR/displayxr-runtime). The plugin talks to the runtime over standard OpenXR plus the `XR_EXT_display_info` / window-binding extensions published in [`displayxr-extensions`](https://github.com/DisplayXR/displayxr-extensions).
+This repo contains the Unity plugin only — the OpenXR runtime, native compositors, and extension headers are in [`displayxr-runtime`](https://github.com/DisplayXR/displayxr-runtime). The plugin talks to the runtime over standard OpenXR plus the `XR_DXR_display_info` / window-binding extensions published in [`displayxr-extensions`](https://github.com/DisplayXR/displayxr-extensions).
 
 Ready-to-open sample projects live in [`displayxr-unity-samples`](https://github.com/DisplayXR/displayxr-unity-samples) (`samples/*`) — use `samples/birp-multipass` to verify plugin changes against a working scene before opening a PR.
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ Unity plugin for rendering on eye-tracked 3D light field displays via the Displa
 
 DisplayXR ships as a custom **Unity display provider** (`IUnityXRDisplay`, the same integration route as Oculus/Varjo/Cardboard) that drives the DisplayXR OpenXR runtime directly while Unity keeps rendering the scene. It provides:
 
-- **Eye-tracked stereo rendering** — runtime-owned Kooima asymmetric frustum projection from real-time eye positions (`XR_EXT_view_rig`)
+- **Eye-tracked stereo rendering** — runtime-owned Kooima asymmetric frustum projection from real-time eye positions (`XR_DXR_view_rig`)
 - **Two stereo rig modes** — Camera-centric (add to existing camera) or display-centric (place a virtual display in the scene)
 - **2D/3D display zones + 2D UI overlay** — frame 3D content to window-pixel zones and route any Canvas to a window-space composition layer with stereo disparity
 - **BiRP, URP, and HDRP** — off-axis projection on all three pipelines (the provider hands Unity a full per-eye projection matrix, so no per-pipeline fix is needed), plus Single-Pass-Instanced (SPI) on URP+Windows+D3D12 and Multi-Pass elsewhere
 - **In-editor Play Mode preview** — pressing Play runs the provider itself, giving full parity with built apps (#171). Play Mode *is* the preview — there is no separate edit-mode preview window.
 
-**How it works:** the provider registers a `DisplayXR Display` display subsystem, binds an OpenXR session to Unity's graphics device, chains the runtime's `XR_EXT_view_rig` descriptor onto `xrLocateViews`, and submits Unity's rendered eye textures back to the runtime compositor via `xrEndFrame`. Enable it under **XR Plug-in Management > Standalone > DisplayXR Display** (see [Enabling the Feature](#enabling-the-feature)). See [`docs~/architecture/xr-display-provider.md`](docs~/architecture/xr-display-provider.md) for the full provider design.
+**How it works:** the provider registers a `DisplayXR Display` display subsystem, binds an OpenXR session to Unity's graphics device, chains the runtime's `XR_DXR_view_rig` descriptor onto `xrLocateViews`, and submits Unity's rendered eye textures back to the runtime compositor via `xrEndFrame`. Enable it under **XR Plug-in Management > Standalone > DisplayXR Display** (see [Enabling the Feature](#enabling-the-feature)). See [`docs~/architecture/xr-display-provider.md`](docs~/architecture/xr-display-provider.md) for the full provider design.
 
 ---
 
@@ -262,7 +262,7 @@ Route a Canvas to a window-space composition layer that the DisplayXR compositor
 | Disparity | 0.0 | Stereo disparity in pixels. 0 = at screen plane, positive = in front |
 | Resolution | 512 | Render texture resolution (square) |
 
-The overlay is submitted as `XrCompositionLayerWindowSpaceEXT` and composited by DisplayXR before display processing. This means 2D UI text stays sharp and is not interlaced — ideal for HUDs, menus, and status displays.
+The overlay is submitted as `XrCompositionLayerWindowSpaceDXR` and composited by DisplayXR before display processing. This means 2D UI text stays sharp and is not interlaced — ideal for HUDs, menus, and status displays.
 
 ---
 
@@ -450,7 +450,7 @@ With the provider active, the **DisplayXRCamera / DisplayXRDisplay inspectors** 
 DisplayXR ships as a custom **`IUnityXRDisplay` display provider** (the shipping path). The provider
 registers a `DisplayXR Display` subsystem, owns an OpenXR session on Unity's graphics device, and hands
 Unity's rendered eye textures to the runtime compositor — Unity keeps rendering the scene (BiRP/URP/HDRP,
-SPI/Multi-Pass), the runtime owns the Kooima math (`XR_EXT_view_rig`).
+SPI/Multi-Pass), the runtime owns the Kooima math (`XR_DXR_view_rig`).
 
 ```
 Unity Editor / Player
@@ -473,7 +473,7 @@ Unity Editor / Player
 │  Native Plugin (C/C++)                                   │
 │  Display provider (IUnityXRDisplay):                     │
 │    session on Unity's device → render params (SPI/MP)   │
-│    xrLocateViews → chain XR_EXT_view_rig descriptor     │
+│    xrLocateViews → chain XR_DXR_view_rig descriptor     │
 │    xrEndFrame → submit projection + zone + 2D layers    │
 └──────────────────────────────────────────────────────────┘
         │ Standard OpenXR API

--- a/Runtime/DisplayXRDisplayInfo.cs
+++ b/Runtime/DisplayXRDisplayInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 namespace DisplayXR
 {
     /// <summary>
-    /// Physical display properties queried from the DisplayXR runtime via XR_EXT_display_info.
+    /// Physical display properties queried from the DisplayXR runtime via XR_DXR_display_info.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct DisplayXRDisplayInfo

--- a/Runtime/DisplayXRGizmoHelpers.cs
+++ b/Runtime/DisplayXRGizmoHelpers.cs
@@ -67,7 +67,7 @@ namespace DisplayXR
 
         /// <summary>
         /// Live Kooima canvas (window on the panel) from the runtime's
-        /// XR_EXT_view_rig raw channel, published each frame by the provider
+        /// XR_DXR_view_rig raw channel, published each frame by the provider
         /// (#189). rect is in panel pixels (top-left origin) — used for the
         /// window-relative eye rebase; size (meters) is the physical canvas —
         /// used for the convergence-plane aspect. Invalid in Edit Mode / on

--- a/Runtime/DisplayXRLocal2D.cs
+++ b/Runtime/DisplayXRLocal2D.cs
@@ -8,7 +8,7 @@ using UnityEngine.Rendering;
 namespace DisplayXR
 {
     /// <summary>
-    /// Submits a Unity UI Canvas as an OpenXR XrCompositionLayerLocal2DEXT
+    /// Submits a Unity UI Canvas as an OpenXR XrCompositionLayerLocal2DDXR
     /// composition layer (#439/#491) — the modern, mask-based 2D-over-3D path.
     /// The runtime composites this "glass over 3D": the woven 3D under the
     /// layer's pixel rect goes flat 2D (implicit mask) and the Canvas content is
@@ -115,13 +115,13 @@ namespace DisplayXR
 
         void OnEnable()
         {
-            // Submitting an XrCompositionLayerLocal2DEXT when XR_EXT_local_3d_zone
+            // Submitting an XrCompositionLayerLocal2DDXR when XR_DXR_local_3d_zone
             // isn't enabled makes the runtime reject the WHOLE xrEndFrame
             // (XR_ERROR_LAYER_INVALID) — black screen. Gate on it: if the runtime
             // doesn't support Local2D, stay inert (no RT, no submission) so the
             // rest of the scene renders normally.
             //
-            // The provider (the sole backend since #166) enables XR_EXT_local_3d_zone
+            // The provider (the sole backend since #166) enables XR_DXR_local_3d_zone
             // on its own OpenXR instance and is the only thing that submits the Local2D
             // layer, so gate purely on the provider being active. When it isn't (edit
             // mode, or XR not started) stay inert — no RT, no submission — so the rest

--- a/Runtime/DisplayXRNative.cs
+++ b/Runtime/DisplayXRNative.cs
@@ -24,7 +24,7 @@ namespace DisplayXR
         private const string LibName = "displayxr_unity";
 
         /// <summary>
-        /// Get display info queried from runtime via XR_EXT_display_info.
+        /// Get display info queried from runtime via XR_DXR_display_info.
         /// </summary>
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void displayxr_get_display_info(
@@ -51,8 +51,8 @@ namespace DisplayXR
         /// <summary>
         /// (runtime-pvt #191 / displayxr-unity #57) Request the runtime's
         /// transparent-background mode for the next OpenXR session. Sets
-        /// transparentBackgroundEnabled on XrWin32WindowBindingCreateInfoEXT
-        /// (XR_EXT_win32_window_binding spec_version 4) so the runtime opts the
+        /// transparentBackgroundEnabled on XrWin32WindowBindingCreateInfoDXR
+        /// (XR_DXR_win32_window_binding spec_version 4) so the runtime opts the
         /// bound HWND's swapchain into BitBlt (D3D11) or DComp (D3D12)
         /// presentation.
         ///
@@ -89,7 +89,7 @@ namespace DisplayXR
         /// off-axis projection into: its rect ON THE PANEL (panel pixels,
         /// top-left origin) and its physical size (meters). Returns 1 and fills
         /// the out params when valid; returns 0 otherwise. Published each frame
-        /// by the provider from the XR_EXT_view_rig raw channel; used by the
+        /// by the provider from the XR_DXR_view_rig raw channel; used by the
         /// editor Scene-view eye gizmo to draw window-relative eyes + the
         /// convergence-plane aspect Kooima consumes.
         /// </summary>
@@ -205,7 +205,7 @@ namespace DisplayXR
         // ====================================================================
         // Window-space UI overlay (issue #67)
         //
-        // Routes a Canvas RenderTexture to a XrCompositionLayerWindowSpaceEXT
+        // Routes a Canvas RenderTexture to a XrCompositionLayerWindowSpaceDXR
         // composition layer. The native side mirrors the Unity texture into
         // an OpenXR overlay swapchain each frame; the runtime composites it
         // on top of the eye projection.
@@ -235,7 +235,7 @@ namespace DisplayXR
 
         // ====================================================================
         // Local2D overlay (#439/#491) — modern mask-based 2D-over-3D layer
-        // (XrCompositionLayerLocal2DEXT, "glass over 3D"). Replaces the legacy
+        // (XrCompositionLayerLocal2DDXR, "glass over 3D"). Replaces the legacy
         // 2D-surround handoff for in-canvas 2D content (e.g. a speech bubble).
         // ====================================================================
 
@@ -250,7 +250,7 @@ namespace DisplayXR
 
         /// <summary>
         /// Set the destination rect in client-window PIXELS (post-DPI) — the
-        /// XrCompositionLayerLocal2DEXT::rect / mask-tier coordinate space.
+        /// XrCompositionLayerLocal2DDXR::rect / mask-tier coordinate space.
         /// Cheap; safe to call every frame.
         /// </summary>
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]

--- a/Runtime/DisplayXRScreenshot.cs
+++ b/Runtime/DisplayXRScreenshot.cs
@@ -19,12 +19,12 @@ namespace DisplayXR
     /// visual feedback.
     ///
     /// As of #140 (W6 of #396) the capture is runtime-owned: a live session calls
-    /// <c>xrCaptureAtlasEXT</c> (XR_EXT_atlas_capture) via
+    /// <c>xrCaptureAtlasDXR</c> (XR_DXR_atlas_capture) via
     /// <see cref="DisplayXRProvider.CaptureAtlas"/>, the runtime reads back the
     /// compositor's own atlas image and writes the PNG. The plugin no longer does
     /// an app-side <c>AsyncGPUReadback</c> or a hidden-camera Kooima re-render.
     ///
-    /// A live provider session supplies a path prefix to xrCaptureAtlasEXT and the
+    /// A live provider session supplies a path prefix to xrCaptureAtlasDXR and the
     /// runtime writes the PNG on its next composed frame.
     ///
     /// Bind <see cref="Capture"/> to any developer-chosen event (key, button,
@@ -56,7 +56,7 @@ namespace DisplayXR
 
         // Frames to wait after issuing a live (runtime-owned) capture before
         // starting the feedback flash. The flash draws into the same eye buffers
-        // the runtime composites for xrCaptureAtlasEXT, and the runtime grabs its
+        // the runtime composites for xrCaptureAtlasDXR, and the runtime grabs its
         // next composed frame — so starting the flash immediately whites out the
         // saved atlas. Delaying it a few frames lets the clean atlas be captured
         // first.
@@ -79,7 +79,7 @@ namespace DisplayXR
 
         /// <summary>
         /// Request a screenshot. The capture is requested from the runtime via
-        /// xrCaptureAtlasEXT — the runtime reads back its own composited atlas and
+        /// xrCaptureAtlasDXR — the runtime reads back its own composited atlas and
         /// writes the PNG on the next composed frame.
         /// </summary>
         public static void Capture()
@@ -89,13 +89,13 @@ namespace DisplayXR
         }
 
         // ================================================================
-        // Live OpenXR session: runtime-owned capture via xrCaptureAtlasEXT
+        // Live OpenXR session: runtime-owned capture via xrCaptureAtlasDXR
         // ================================================================
 
         private static void CaptureLive()
         {
             // The custom display Provider (epic #166) fulfils the capture runtime-side
-            // via xrCaptureAtlasEXT.
+            // via xrCaptureAtlasDXR.
 
             // Built-app stereo is two-view (Unity SetStereoViewMatrix L/R); this
             // matches the cols x rows the runtime composes for a standard 3D mode.
@@ -131,8 +131,8 @@ namespace DisplayXR
             bool ok = DisplayXRProvider.CaptureAtlas(prefix, projectionOnly: true);
             if (!ok)
             {
-                Fail("xrCaptureAtlasEXT unavailable or rejected the request "
-                     + "(runtime missing XR_EXT_atlas_capture or no live session)");
+                Fail("xrCaptureAtlasDXR unavailable or rejected the request "
+                     + "(runtime missing XR_DXR_atlas_capture or no live session)");
                 return;
             }
 

--- a/Runtime/DisplayXRSplash.cs
+++ b/Runtime/DisplayXRSplash.cs
@@ -98,7 +98,7 @@ namespace DisplayXR
 
             // Wait for the runtime to report display geometry so we can size the
             // logo to the physical display. Fall back after ~2 s. Read the
-            // provider's own XR_EXT_display_info.
+            // provider's own XR_DXR_display_info.
             float t = 0f;
             float displayH = 0.19f;
             while (t < 2f)

--- a/Runtime/DisplayXRTransparentOverlay.cs
+++ b/Runtime/DisplayXRTransparentOverlay.cs
@@ -319,7 +319,7 @@ namespace DisplayXR
 #elif UNITY_STANDALONE_OSX
             // (#85 Phase 1) Flip Unity's NSWindow opaque flag so the desktop
             // shows through alpha=0 regions. Runtime handles its own
-            // CAMetalLayer + NSWindow via XR_EXT_cocoa_window_binding v5; the
+            // CAMetalLayer + NSWindow via XR_DXR_cocoa_window_binding v5; the
             // Unity-owned NSWindow is the app's responsibility. Skip in the
             // editor unless we're in Play Mode — at edit time the game-view
             // hasn't been built and we'd mutate the wrong window.

--- a/Runtime/DisplayXRWindowSpaceUI.cs
+++ b/Runtime/DisplayXRWindowSpaceUI.cs
@@ -7,7 +7,7 @@ using UnityEngine.Experimental.Rendering;
 namespace DisplayXR
 {
     /// <summary>
-    /// Submits a Unity UI Canvas as an OpenXR XrCompositionLayerWindowSpaceEXT
+    /// Submits a Unity UI Canvas as an OpenXR XrCompositionLayerWindowSpaceDXR
     /// composition layer.
     ///
     /// IMPORTANT API: this component takes over the Canvas it's attached to and

--- a/Runtime/Provider/DisplayXRProvider.cs
+++ b/Runtime/Provider/DisplayXRProvider.cs
@@ -70,7 +70,7 @@ namespace DisplayXR
             IsRunning && DisplayXRProviderNative.dxr_prov_set_eye_tracking_mode(manual ? 1 : 0) != 0;
 
         /// <summary>
-        /// App-facing atlas screenshot via XR_EXT_atlas_capture (#140). The runtime
+        /// App-facing atlas screenshot via XR_DXR_atlas_capture (#140). The runtime
         /// reads back its own compositor atlas and writes
         /// "&lt;pathPrefix&gt;_atlas_&lt;viewCount&gt;_&lt;cols&gt;x&lt;rows&gt;.png" on the next composed
         /// frame (non-blocking). Only captures while weaving (3D). Returns true if the
@@ -80,7 +80,7 @@ namespace DisplayXR
             IsRunning && DisplayXRProviderNative.dxr_prov_capture_atlas(pathPrefix, projectionOnly ? 1 : 0) != 0;
 
         /// <summary>
-        /// Provider display geometry (XR_EXT_display_info).
+        /// Provider display geometry (XR_DXR_display_info).
         /// Returns false if the provider isn't running or the runtime hasn't reported
         /// valid geometry yet.
         /// </summary>

--- a/Runtime/Provider/DisplayXRProviderNative.cs
+++ b/Runtime/Provider/DisplayXRProviderNative.cs
@@ -20,7 +20,7 @@ namespace DisplayXR
     {
         private const string LibName = "displayxr_unity";
 
-        /// <summary>Display geometry surfaced from XR_EXT_display_info (mirrors DxrProvDisplayInfo).</summary>
+        /// <summary>Display geometry surfaced from XR_DXR_display_info (mirrors DxrProvDisplayInfo).</summary>
         [StructLayout(LayoutKind.Sequential)]
         public struct DisplayInfo
         {
@@ -226,7 +226,7 @@ namespace DisplayXR
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int dxr_prov_set_eye_tracking_mode(int manual);
 
-        // ---- Atlas capture (XR_EXT_atlas_capture, #140) ----------------------
+        // ---- Atlas capture (XR_DXR_atlas_capture, #140) ----------------------
 
         [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
         public static extern int dxr_prov_capture_atlas(

--- a/Samples~/MinimalTransparent/MinimalTransparent.cs
+++ b/Samples~/MinimalTransparent/MinimalTransparent.cs
@@ -20,7 +20,7 @@ namespace DisplayXR.Samples
         // PHASE 1: BEFORE xrCreateSession.
         // SubsystemRegistration runs earlier than the OpenXR loader's session
         // creation, so the runtime sees the transparent-background flag when
-        // constructing XrWin32WindowBindingCreateInfoEXT. OnEnable on a scene
+        // constructing XrWin32WindowBindingCreateInfoDXR. OnEnable on a scene
         // component would be too late — the session is already up.
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         static void Bootstrap()

--- a/Samples~/MinimalTransparent/README.md
+++ b/Samples~/MinimalTransparent/README.md
@@ -83,7 +83,7 @@ DisplayXR is an OpenXR runtime that implements the standard Khronos API
 plus a few **vendor extensions** for 3D-display-specific concerns. The
 transparent overlay relies on:
 
-### `XR_EXT_win32_window_binding` (spec v5) and `XR_EXT_cocoa_window_binding`
+### `XR_DXR_win32_window_binding` (spec v5) and `XR_DXR_cocoa_window_binding`
 
 The app passes the application's `HWND` (or `NSView*`) to the runtime via
 these extensions, chained off `XrSessionCreateInfo.next` at
@@ -99,7 +99,7 @@ field for transparency:
 The struct definition lives in `native~/displayxr_extensions.h`. v5 is what
 the plugin and runtime both implement.
 
-### `XR_EXT_display_info`
+### `XR_DXR_display_info`
 
 Not used directly by this sample, but every DisplayXR scene depends on it.
 The runtime sends back the physical display dimensions, supported eye
@@ -167,7 +167,7 @@ PLUGIN  (DisplayXR Unity package — C# in Runtime/, native in native~/)
  ├─ DisplayXRFeature.OnInstanceCreate:
  │   └─ SetEnvironmentBlendMode(AlphaBlend) so Unity preserves alpha
  └─ Native:
-     ├─ Hooks xrCreateSession; fills XrWin32WindowBindingCreateInfoEXT
+     ├─ Hooks xrCreateSession; fills XrWin32WindowBindingCreateInfoDXR
      │   with transparentBackgroundEnabled=1, chromaKeyColor=0
      ├─ Creates top-level WS_EX_NOREDIRECTIONBITMAP overlay HWND
      ├─ Cloaks + moves Unity main HWND off-screen for click-through
@@ -219,7 +219,7 @@ OS / DWM (Windows) / Cocoa (macOS)
   `docs~/adr/ADR-004-camera-vs-display-mode.md`
 - Runtime extension specs: see the [DisplayXR runtime
   repo](https://github.com/DisplayXR/displayxr-runtime), `docs/specs/`
-  directory — `XR_EXT_display_info.md`, `XR_EXT_win32_window_binding.md`
+  directory — `XR_DXR_display_info.md`, `XR_DXR_win32_window_binding.md`
 - Issue #57 on `DisplayXR/displayxr-unity` — the original feature request
   with the full problem framing.
 - Issue #103 on `DisplayXR/displayxr-unity` — the tracking ticket for

--- a/docs~/adr/ADR-003-native-preview-window.md
+++ b/docs~/adr/ADR-003-native-preview-window.md
@@ -14,7 +14,7 @@ The original editor preview used a shared texture approach: the runtime composit
 
 - IOSurface creation + MTLTexture wrapping on macOS
 - D3D12 cross-device shared texture + DXGI handle on Windows
-- Canvas rect signaling (`xrSetSharedTextureOutputRectEXT`)
+- Canvas rect signaling (`xrSetSharedTextureOutputRectDXR`)
 - UV cropping for aspect ratio mismatch
 - Y-flip handling for Metal
 - Complex teardown (destroy IOSurface before session, but after compositor)

--- a/docs~/adr/ADR-007-render-path-by-view-count.md
+++ b/docs~/adr/ADR-007-render-path-by-view-count.md
@@ -21,7 +21,7 @@ so this ceiling is a real constraint, not a hypothetical.
 ## Decision
 
 The plugin selects a render path from the display's advertised maximum view count
-(from `XR_EXT_display_info` / the enumerated modes' view counts, already read at
+(from `XR_DXR_display_info` / the enumerated modes' view counts, already read at
 subsystem start):
 
 - **≤ 8 views — the provider path** (Unity `IUnityXRDisplay`) — eye-tracked stereo
@@ -63,7 +63,7 @@ marked as the quilt seed. Whoever promotes it must:
   to quad (≤ 8 views) is the easy win — generalize the existing multi-zone
   N-render-pass machinery in `displayxr_display_provider.cpp` `PopulateNextFrameDesc`
   from "N zones each 2-view" to "1 display, N views" (arraySize=N swapchain, submit
-  views `imageArrayIndex` 0..N-1). It needs the runtime `XR_EXT_view_rig` to return
+  views `imageArrayIndex` 0..N-1). It needs the runtime `XR_DXR_view_rig` to return
   N views + an N-view DP weave. The multi-zone code is the proof-of-concept.
 
 ## References

--- a/docs~/architecture/click-through-mask.md
+++ b/docs~/architecture/click-through-mask.md
@@ -73,7 +73,7 @@ two ways (`displayxr_win32.c`):
 weaves the 3D into. The app is responsible for keeping them equal:
 
 - **Weave placement** ← the provider zone: `DisplayXRProvider.SetZoneRect(…)` →
-  `dxr_prov_set_3d_zone_rect` → `XrDisplayZoneEXT`.
+  `dxr_prov_set_3d_zone_rect` → `XrDisplayZoneDXR`.
 - **Mask placement** ← the canvas rect: `DisplayXRNative.displayxr_set_canvas_rect(zoneRect)`
   → `s_canvas_rect` (in `displayxr_native_shared.cpp`), read back by
   `displayxr_get_canvas_rect_px`.

--- a/docs~/architecture/xr-display-provider.md
+++ b/docs~/architecture/xr-display-provider.md
@@ -8,14 +8,14 @@ The plugin **used to** reach the runtime via an **OpenXR API-layer hook**
 (`displayxr_hooks.cpp`) riding Unity's own OpenXR plugin. In that model the runtime
 treated Unity as a **fixed-resolution, always-2-view "legacy compromise" app**
 (see `displayxr-runtime/docs/architecture/unity-d3d12-app-path.md`):
-`XR_EXT_display_info` off, mode keys disabled, per-view resolution fixed at session
+`XR_DXR_display_info` off, mode keys disabled, per-view resolution fixed at session
 start, and the plugin coupled to Unity's OpenXR-stack internals.
 
 Epic #166 replaced that hook with a **custom `IUnityXRDisplay` Display Provider**
 (the route Oculus / Varjo / Google Cardboard use), and this provider is now the
 **sole shipping backend** — the hook and the standalone editor-preview session were
 removed. We drive the session; Unity still renders (keeping **SPI + URP/HDRP**); we
-enable `XR_EXT_display_info` so the runtime treats us as a **first-class extension
+enable `XR_DXR_display_info` so the runtime treats us as a **first-class extension
 app** — the Unity analog of the UE plugin (`unreal-d3d12-app-path.md`). The
 historical M1–M2 bring-up sections below document how the architecture was proven
 and hardened on hardware. For the >8-view (light-field/quilt) roadmap that layers on
@@ -27,7 +27,7 @@ top of this provider, see [ADR-007](../adr/ADR-007-render-path-by-view-count.md)
 |---|---|
 | `Runtime/UnitySubsystemsManifest.json` | Registers the display subsystem (`name: "DisplayXR"`, display `id: "DisplayXR Display"`, `libraryName: "displayxr_unity"`). Unity scans package manifests at load. |
 | `native~/displayxr_xrprovider/displayxr_display_provider.cpp` | Unity-facing half: `RegisterLifecycleProvider`, main-thread + graphics-thread provider callbacks, `CreateTexture` handoff, per-frame `PopulateNextFrameDesc` / `SubmitCurrentFrame`. |
-| `native~/displayxr_xrprovider/displayxr_provider_session.{h,cpp}` | Runtime-facing half: loads the DisplayXR runtime via `xrNegotiateLoaderRuntimeInterface`, creates instance/system/session on **Unity's D3D12 device**, enables EXT extensions, creates the `arraySize=2` (SPI) swapchain, consumes `XR_EXT_view_rig` render-ready views, submits the 2-view projection layer. |
+| `native~/displayxr_xrprovider/displayxr_provider_session.{h,cpp}` | Runtime-facing half: loads the DisplayXR runtime via `xrNegotiateLoaderRuntimeInterface`, creates instance/system/session on **Unity's D3D12 device**, enables EXT extensions, creates the `arraySize=2` (SPI) swapchain, consumes `XR_DXR_view_rig` render-ready views, submits the 2-view projection layer. |
 | `native~/displayxr_unity_plugin.cpp` | `UnityPluginLoad` calls `displayxr_register_xr_display_provider(ifaces)`. Single DLL — no second plugin. |
 | `native~/unity_pluginapi/` | Vendored Unity XR SDK headers (`IUnityXRDisplay.h`, `UnitySubsystemTypes.h`, `UnityXRTypes.h`, …) — Unity ships only graphics headers in the editor; the XR provider headers are sourced from the Unity XR SDK (Unity Companion License). |
 
@@ -53,7 +53,7 @@ GfxStart (render thread)
   ├─ Get Unity ID3D12Device + queue (IUnityGraphicsD3D12v8::GetDevice/GetCommandQueue)
   └─ dxr_prov_session_start ───────►  xrNegotiateLoaderRuntimeInterface (load runtime DLL)
                                        xrCreateInstance(+display_info,+D3D12,+win32_binding,+view_rig)
-                                       xrGetSystem / xrGetSystemProperties(XrDisplayInfoEXT)
+                                       xrGetSystem / xrGetSystemProperties(XrDisplayInfoDXR)
                                        xrGetD3D12GraphicsRequirementsKHR (LUID; Unity's device honored)
                                        xrCreateSession(GraphicsBindingD3D12{Unity device,queue} → win_binding)
                                        xrCreateReferenceSpace(LOCAL)
@@ -61,7 +61,7 @@ GfxStart (render thread)
 PopulateNextFrameDesc (per frame)
   ├─ dxr_prov_poll_events ─────────►  xrPollEvent → on READY: xrBeginSession + create swapchain
   ├─ create_textures_if_ready ─────►  CreateTexture(nativePtr = runtime swapchain image[i])  ← zero-copy
-  ├─ dxr_prov_begin_frame ─────────►  xrWaitFrame + xrBeginFrame + xrLocateViews(XrDisplayRigEXT) + Acquire/Wait
+  ├─ dxr_prov_begin_frame ─────────►  xrWaitFrame + xrBeginFrame + xrLocateViews(XrDisplayRigDXR) + Acquire/Wait
   └─ fill 1 RenderPass × 2 RenderParams (slices 0/1, projection from view fov)
 [Unity renders both eyes into the acquired swapchain image's 2 array slices]
 SubmitCurrentFrame
@@ -130,7 +130,7 @@ compositor-owned `ID3D12Resource`s on Unity's device"). Then:
 - `renderParams[eye].textureArraySlice = eye` (0 = left, 1 = right).
 - `renderParams[eye].projection` = `kUnityXRProjectionTypeHalfAngles` with
   `{left,right,top,bottom} = tan(fov.angleLeft/Right/Up/Down)` from the runtime's
-  render-ready `XR_EXT_view_rig` view.
+  render-ready `XR_DXR_view_rig` view.
 - `renderParams[eye].deviceAnchorToEyePose` = the view pose, converted OpenXR
   (right-handed, −Z fwd) → Unity (left-handed, +Z fwd).
 - `GfxStart` sets `renderingCaps.noSinglePassRenderingSupport = false`.
@@ -140,10 +140,10 @@ the runtime's shipped SPI fix (per-view SRV `FirstArraySlice = imageArrayIndex`)
 
 ## Extensions enabled (extension-app, not legacy)
 
-`XR_EXT_display_info` (geometry + becomes an extension app), `XR_KHR_D3D12_enable`
-(graphics binding), `XR_EXT_win32_window_binding` (weave target window),
-`XR_EXT_view_rig` (runtime-owned Kooima → render-ready views; probed before
-enabling, since older runtimes reject unknown extensions). Without `XR_EXT_view_rig`
+`XR_DXR_display_info` (geometry + becomes an extension app), `XR_KHR_D3D12_enable`
+(graphics binding), `XR_DXR_win32_window_binding` (weave target window),
+`XR_DXR_view_rig` (runtime-owned Kooima → render-ready views; probed before
+enabling, since older runtimes reject unknown extensions). Without `XR_DXR_view_rig`
 the provider logs a one-shot WARN and produces no stereo (same contract as the hook
 / standalone).
 
@@ -168,8 +168,8 @@ rig**, not fixed defaults — so a tracked face gets correct depth/parallax.
   hook-path LateUpdate push, which is inert in provider mode because
   `DisplayXRFeature` needs Unity's OpenXR loader). It respects the same gating
   (`SplashActive`, active-rig-only) as the rigs.
-- Native `dxr_prov_begin_frame` chains `XrDisplayRigEXT` (display-centric) or
-  `XrCameraRigEXT` (camera-centric) exactly like `displayxr_standalone.cpp`. The
+- Native `dxr_prov_begin_frame` chains `XrDisplayRigDXR` (display-centric) or
+  `XrCameraRigDXR` (camera-centric) exactly like `displayxr_standalone.cpp`. The
   rig pose is converted Unity→OpenXR (negate posZ, negate quat X/Y) in
   `dxr_prov_set_display_pose`; scene scale (`lossyScale`, scale-as-zoom) is folded
   into `virtualDisplayHeight` / `convergenceDiopters` on the C# side, matching the
@@ -197,16 +197,16 @@ rig**, not fixed defaults — so a tracked face gets correct depth/parallax.
 ### C. Mode enumeration + control + events
 
 - Native exports surface the enumerated modes (`dxr_prov_get_mode_count/info`),
-  the active mode, and `xrRequestDisplayRenderingModeEXT` /
-  `xrRequestDisplayModeEXT` / `xrRequestEyeTrackingModeEXT` (all soft-resolved —
+  the active mode, and `xrRequestDisplayRenderingModeDXR` /
+  `xrRequestDisplayModeDXR` / `xrRequestEyeTrackingModeDXR` (all soft-resolved —
   inert on an older runtime).
-- `dxr_prov_poll_events` handles `XrEventDataRenderingModeChangedEXT` (re-enumerate
+- `dxr_prov_poll_events` handles `XrEventDataRenderingModeChangedDXR` (re-enumerate
   modes + re-derive tiling/resolution live), `…HardwareDisplayStateChangedEXT`,
   and `…EyeTrackingStateChangedEXT`, latching each into atomic read-and-clear
   flags. The driver pumps them into `DisplayXRProvider`'s C# events. Mode
   *keybinding* stays app policy — the plugin only exposes the API. The three event
   structs were added to `displayxr_extensions.h` verbatim from the runtime's
-  `XR_EXT_display_info.h`.
+  `XR_DXR_display_info.h`.
 
 ### Loader (XR Plug-in Management)
 
@@ -345,7 +345,7 @@ needs to change *where it reads from*, not the downstream logic:
 |---|---|---|
 | `DisplayXRFeature.Instance.GetStereoMatrices(...)` | `displayxr_get_stereo_matrices` (provider-populated via `ps_publish_stereo_matrices`) | `DisplayXRTransparentOverlay` silhouette/hit-test (URP eye_world view+proj — else the click-through silhouette truncates popped-out geometry, bc001ce). *(The former URP `KooimaProjectionFixFeature` also read this; it was removed in v2.2.0 once the provider began handing Unity a full projection matrix — see #22.)* |
 | hook `LateUpdate` push of `dxr_set_tunables` / display pose | `DisplayXRProviderDriver` per-frame `dxr_prov_set_tunables` / `dxr_prov_set_display_pose` | display/camera rig tunables |
-| `OpenXRRuntime.IsExtensionEnabled("XR_EXT_local_3d_zone")` gate | `DisplayXRProviderDriver.IsActive` | `DisplayXRLocal2D` bridge branch |
+| `OpenXRRuntime.IsExtensionEnabled("XR_DXR_local_3d_zone")` gate | `DisplayXRProviderDriver.IsActive` | `DisplayXRLocal2D` bridge branch |
 | `SetEnvironmentBlendMode(AlphaBlend)` on the OpenXR feature | `dxr_prov_set_transparent_background` | `DisplayXRTransparentOverlay` |
 | foreground-clip globals from `GetStereoMatrices` (rig URP branch) | `dxr_prov_get_eye_clip` published in `DisplayXRDisplay.PublishProviderForegroundClip` | `DisplayXR/ForegroundClipURP` |
 

--- a/docs~/experiments/macos-metal-recon.md
+++ b/docs~/experiments/macos-metal-recon.md
@@ -7,7 +7,7 @@ Metal XR probe is deferred to Phase 2 first light (it needs a compiling provider
 ## TL;DR
 
 The runtime's macOS build is **already provider-ready** — every extension the provider
-needs is advertised on macOS, including `XR_EXT_view_rig` at SPEC_VERSION 3 and the
+needs is advertised on macOS, including `XR_DXR_view_rig` at SPEC_VERSION 3 and the
 Metal graphics binding. The gap is entirely plugin-side: the provider is compiled only
 under `if(WIN32)` and the shipped macOS bundle exports zero `dxr_prov_*` symbols, so
 the C# loader throws `EntryPointNotFoundException` before subsystem creation. The
@@ -20,16 +20,16 @@ core is backend-agnostic and ports unchanged.
 | Extension | SPEC_VERSION | Windows | macOS |
 |---|---|---|---|
 | `XR_KHR_metal_enable` (+ `XR_KHRX2_metal_enable` alias) | 2 | n/a | **yes** |
-| `XR_EXT_view_rig` | **3** (provider needs ≥2) | yes | **yes** (no platform gate) |
-| `XR_EXT_display_info` | 15 | yes | yes |
-| `XR_EXT_atlas_capture` | 3 | yes | yes |
-| `XR_EXT_display_zones` | 1 | yes | yes |
-| `XR_EXT_local_3d_zone` | 4 | yes | yes |
-| `XR_EXT_cocoa_window_binding` | 6 (incl. `transparentBackgroundEnabled`) | n/a | yes |
-| `XR_EXT_win32_window_binding` | — | yes | n/a |
-| `XR_EXT_weave` | — | yes | **no — Win32-gated** |
-| `XR_EXT_workspace_file_dialog` | — | yes | no — Win32-gated |
-| `XR_EXT_mcp_tools` | — | yes | yes |
+| `XR_DXR_view_rig` | **3** (provider needs ≥2) | yes | **yes** (no platform gate) |
+| `XR_DXR_display_info` | 15 | yes | yes |
+| `XR_DXR_atlas_capture` | 3 | yes | yes |
+| `XR_DXR_display_zones` | 1 | yes | yes |
+| `XR_DXR_local_3d_zone` | 4 | yes | yes |
+| `XR_DXR_cocoa_window_binding` | 6 (incl. `transparentBackgroundEnabled`) | n/a | yes |
+| `XR_DXR_win32_window_binding` | — | yes | n/a |
+| `XR_DXR_weave` | — | yes | **no — Win32-gated** |
+| `XR_DXR_workspace_file_dialog` | — | yes | no — Win32-gated |
+| `XR_DXR_mcp_tools` | — | yes | yes |
 
 Local2D and the window-space-UI HUD are **compositor-layer features, not separate
 extensions** — they ride the standard layer path, and the runtime's Metal compositor
@@ -76,7 +76,7 @@ already has the Local2D flatten pipeline (`oxr_session_gfx_metal_native.c`).
   stale — there is no IOSurface-backed texture creation and no `MTLSharedEvent` code
   anywhere in the repo. Any own-device bridge would be new code. (The IOSurface
   framework is linked, unused.)
-- **`XR_EXT_view_rig` is at SPEC_VERSION 3** (the epic notes said "needs 2") and is
+- **`XR_DXR_view_rig` is at SPEC_VERSION 3** (the epic notes said "needs 2") and is
   advertised unconditionally — no runtime work needed for macOS Kooima.
 - The SA-era Metal backend (`displayxr_standalone_metal_backend.cpp`) never needed a
   bridge: all its cross-device methods are stubs, because Metal's unified device model

--- a/docs~/roadmap/transparent-overlay-handoff.md
+++ b/docs~/roadmap/transparent-overlay-handoff.md
@@ -219,10 +219,10 @@ Unity rendering ───► OpenXR eye swapchains ───► Runtime weaver �
 
 ### Wire format (`native~/displayxr_extensions.h`)
 
-`XR_EXT_win32_window_binding` `SPEC_VERSION = 5`. Field-at-end struct:
+`XR_DXR_win32_window_binding` `SPEC_VERSION = 5`. Field-at-end struct:
 
 ```c
-typedef struct XrWin32WindowBindingCreateInfoEXT {
+typedef struct XrWin32WindowBindingCreateInfoDXR {
     XrStructureType        type;
     const void            *next;
     void                  *windowHandle;          // HWND
@@ -231,7 +231,7 @@ typedef struct XrWin32WindowBindingCreateInfoEXT {
     void                  *sharedTextureHandle;
     XrBool32               transparentBackgroundEnabled;  // v4: opt-in BitBlt (D3D11) / DComp (D3D12)
     uint32_t               chromaKeyColor;                // v5: COLORREF, post-weave alpha conversion
-} XrWin32WindowBindingCreateInfoEXT;
+} XrWin32WindowBindingCreateInfoDXR;
 ```
 
 Plugin populates both fields in two construction sites in `displayxr_hooks.cpp` (the `win32_inject_window_binding` helper used by D3D11/D3D12 backends, and the `xrCreateSession` chain-walking fallback).
@@ -277,7 +277,7 @@ We tried each of these first and they all failed for documented reasons — don'
 |------|---------|
 | `Runtime/DisplayXRTransparentOverlay.cs` | The user-facing component |
 | `Runtime/DisplayXRNative.cs` | DllImport bindings — search for `transparent` |
-| `native~/displayxr_extensions.h` | Embedded `XR_EXT_win32_window_binding` v5 header |
+| `native~/displayxr_extensions.h` | Embedded `XR_DXR_win32_window_binding` v5 header |
 | `native~/displayxr_hooks.cpp` | Window-binding struct construction (two sites — both populate v5 fields). Also `displayxr_set_transparent_background` and `displayxr_set_transparent_chroma_key` C-side setters. |
 | `native~/displayxr_shared_state.{h,cpp}` | `transparent_background_requested` + `transparent_chroma_key_color` flags; preserved across `displayxr_state_init` memset |
 | `native~/displayxr_win32.c` | All the Windows-specific window magic. `displayxr_get_app_main_view` (top-level vs child branch), `displayxr_set_transparent_overlay` (style flip + cloak), `parent_subclass_proc` (WM_NCHITTEST hit-rect, WM_SIZE/MOVE tracking), `find_unity_hwnd` (skip overlay class) |

--- a/native~/CMakeLists.txt
+++ b/native~/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 # --- displayxr::math removed (#396 W7) ---
 # The plugin no longer computes Kooima locally — the DisplayXR runtime owns the
-# view-rig math via XR_EXT_view_rig, and the plugin consumes render-ready
+# view-rig math via XR_DXR_view_rig, and the plugin consumes render-ready
 # XrView{pose,fov}. The former displayxr-common (display3d/camera3d) dependency
 # is gone; do NOT re-add it (see the no-vendored-math drift guard).
 

--- a/native~/displayxr_exports.h
+++ b/native~/displayxr_exports.h
@@ -61,8 +61,8 @@ DISPLAYXR_EXPORT void displayxr_set_editor_mode(int enabled);
 
 /// (issue runtime-pvt #191 / displayxr-unity #57) Request the runtime's
 /// transparent-background mode for the next OpenXR session. Sets the
-/// transparentBackgroundEnabled field on XrWin32WindowBindingCreateInfoEXT
-/// (XR_EXT_win32_window_binding spec_version 4) when the next session is
+/// transparentBackgroundEnabled field on XrWin32WindowBindingCreateInfoDXR
+/// (XR_DXR_win32_window_binding spec_version 4) when the next session is
 /// created, opting the bound HWND's swapchain into BitBlt (D3D11) or DComp
 /// (D3D12) presentation.
 ///
@@ -153,7 +153,7 @@ DISPLAYXR_EXPORT void displayxr_get_shared_texture(void **native_ptr,
                                                   int *ready);
 
 /// Set the canvas output rect for shared texture compositing (play mode).
-/// Calls xrSetSharedTextureOutputRectEXT on the runtime session.
+/// Calls xrSetSharedTextureOutputRectDXR on the runtime session.
 DISPLAYXR_EXPORT void displayxr_set_canvas_rect(
     int32_t x, int32_t y, uint32_t w, uint32_t h);
 

--- a/native~/displayxr_extensions.h
+++ b/native~/displayxr_extensions.h
@@ -12,13 +12,13 @@
 extern "C" {
 #endif
 
-// --- XR_EXT_display_info ---
-#define XR_EXT_DISPLAY_INFO_EXTENSION_NAME "XR_EXT_display_info"
-#define XR_EXT_DISPLAY_INFO_SPEC_VERSION 12
+// --- XR_DXR_display_info ---
+#define XR_DXR_DISPLAY_INFO_EXTENSION_NAME "XR_DXR_display_info"
+#define XR_DXR_DISPLAY_INFO_SPEC_VERSION 12
 
-#define XR_TYPE_DISPLAY_INFO_EXT ((XrStructureType)1000999003)
+#define XR_TYPE_DISPLAY_INFO_DXR ((XrStructureType)1004999003)
 
-typedef struct XrDisplayInfoEXT {
+typedef struct XrDisplayInfoDXR {
     XrStructureType type;
     void *next;
     XrExtent2Df displaySizeMeters;
@@ -27,22 +27,22 @@ typedef struct XrDisplayInfoEXT {
     float recommendedViewScaleY;
     uint32_t displayPixelWidth;
     uint32_t displayPixelHeight;
-} XrDisplayInfoEXT;
+} XrDisplayInfoDXR;
 
-typedef enum XrDisplayModeEXT {
-    XR_DISPLAY_MODE_2D_EXT = 0,
-    XR_DISPLAY_MODE_3D_EXT = 1,
-    XR_DISPLAY_MODE_MAX_ENUM_EXT = 0x7FFFFFFF
-} XrDisplayModeEXT;
+typedef enum XrDisplayModeDXR {
+    XR_DISPLAY_MODE_2D_DXR = 0,
+    XR_DISPLAY_MODE_3D_DXR = 1,
+    XR_DISPLAY_MODE_MAX_ENUM_DXR = 0x7FFFFFFF
+} XrDisplayModeDXR;
 
-typedef XrResult(XRAPI_PTR *PFN_xrRequestDisplayModeEXT)(XrSession session, XrDisplayModeEXT displayMode);
+typedef XrResult(XRAPI_PTR *PFN_xrRequestDisplayModeDXR)(XrSession session, XrDisplayModeDXR displayMode);
 
 // --- Display rendering mode (vendor-specific: SBS, anaglyph, lenticular, etc.) ---
-typedef XrResult(XRAPI_PTR *PFN_xrRequestDisplayRenderingModeEXT)(XrSession session, uint32_t modeIndex);
+typedef XrResult(XRAPI_PTR *PFN_xrRequestDisplayRenderingModeDXR)(XrSession session, uint32_t modeIndex);
 
-#define XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT ((XrStructureType)1000999008)
+#define XR_TYPE_DISPLAY_RENDERING_MODE_INFO_DXR ((XrStructureType)1004999008)
 
-typedef struct XrDisplayRenderingModeInfoEXT {
+typedef struct XrDisplayRenderingModeInfoDXR {
     XrStructureType type;
     void *next;
     uint32_t modeIndex;
@@ -57,75 +57,75 @@ typedef struct XrDisplayRenderingModeInfoEXT {
     uint32_t viewHeightPixels;
     // v13 (DisplayXR runtime v1.4.0+): isActive marks the current mode for
     // this session; isRequestable is false for non-controller workspace
-    // clients (runtime drops xrRequestDisplayRenderingModeEXT). Plugin
+    // clients (runtime drops xrRequestDisplayRenderingModeDXR). Plugin
     // doesn't currently consume them, but the struct sizeof must match
-    // the runtime's so xrEnumerateDisplayRenderingModesEXT writes modes[i]
+    // the runtime's so xrEnumerateDisplayRenderingModesDXR writes modes[i]
     // at the right stride. See DisplayXR/displayxr-runtime#234.
     XrBool32 isActive;
     XrBool32 isRequestable;
-} XrDisplayRenderingModeInfoEXT;
+} XrDisplayRenderingModeInfoDXR;
 
-typedef XrResult(XRAPI_PTR *PFN_xrEnumerateDisplayRenderingModesEXT)(
+typedef XrResult(XRAPI_PTR *PFN_xrEnumerateDisplayRenderingModesDXR)(
     XrSession session,
     uint32_t modeCapacityInput,
     uint32_t *modeCountOutput,
-    XrDisplayRenderingModeInfoEXT *modes);
+    XrDisplayRenderingModeInfoDXR *modes);
 
-// --- Eye-tracking mode control (XR_EXT_display_info v6) ---
-// Verbatim from the runtime's openxr/XR_EXT_display_info.h. MANAGED (0) is the
+// --- Eye-tracking mode control (XR_DXR_display_info v6) ---
+// Verbatim from the runtime's openxr/XR_DXR_display_info.h. MANAGED (0) is the
 // default (vendor SDK owns transitions); MANUAL (1) gives unfiltered positions +
 // an explicit isTracking flag the app drives its own 2D/3D ramp from.
-typedef enum XrEyeTrackingModeEXT {
-    XR_EYE_TRACKING_MODE_MANAGED_EXT  = 0,
-    XR_EYE_TRACKING_MODE_MANUAL_EXT   = 1,
-    XR_EYE_TRACKING_MODE_MAX_ENUM_EXT = 0x7FFFFFFF
-} XrEyeTrackingModeEXT;
+typedef enum XrEyeTrackingModeDXR {
+    XR_EYE_TRACKING_MODE_MANAGED_DXR  = 0,
+    XR_EYE_TRACKING_MODE_MANUAL_DXR   = 1,
+    XR_EYE_TRACKING_MODE_MAX_ENUM_DXR = 0x7FFFFFFF
+} XrEyeTrackingModeDXR;
 
-typedef XrResult(XRAPI_PTR *PFN_xrRequestEyeTrackingModeEXT)(
-    XrSession session, XrEyeTrackingModeEXT mode);
+typedef XrResult(XRAPI_PTR *PFN_xrRequestEyeTrackingModeDXR)(
+    XrSession session, XrEyeTrackingModeDXR mode);
 
-// --- Unified display-mode events (XR_EXT_display_info v10/v14) ---
+// --- Unified display-mode events (XR_DXR_display_info v10/v14) ---
 // Verbatim struct layouts + type values from the runtime header. The provider's
 // xrPollEvent loop consumes these to reconfigure tiling/resolution live and to
 // notify C#. (Not used by the hook/standalone path; provider-only for #166 M2.)
-#define XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT         ((XrStructureType)1000999010)
-#define XR_TYPE_EVENT_DATA_HARDWARE_DISPLAY_STATE_CHANGED_EXT ((XrStructureType)1000999011)
-#define XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT     ((XrStructureType)1000999013)
+#define XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_DXR         ((XrStructureType)1004999010)
+#define XR_TYPE_EVENT_DATA_HARDWARE_DISPLAY_STATE_CHANGED_DXR ((XrStructureType)1004999011)
+#define XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_DXR     ((XrStructureType)1004999013)
 
-typedef struct XrEventDataRenderingModeChangedEXT {
-    XrStructureType type; // Must be XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT
+typedef struct XrEventDataRenderingModeChangedDXR {
+    XrStructureType type; // Must be XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_DXR
     const void *next;
     XrSession session;
     uint32_t previousModeIndex;
     uint32_t currentModeIndex;
-} XrEventDataRenderingModeChangedEXT;
+} XrEventDataRenderingModeChangedDXR;
 
-typedef struct XrEventDataHardwareDisplayStateChangedEXT {
-    XrStructureType type; // Must be XR_TYPE_EVENT_DATA_HARDWARE_DISPLAY_STATE_CHANGED_EXT
+typedef struct XrEventDataHardwareDisplayStateChangedDXR {
+    XrStructureType type; // Must be XR_TYPE_EVENT_DATA_HARDWARE_DISPLAY_STATE_CHANGED_DXR
     const void *next;
     XrSession session;
     XrBool32 hardwareDisplay3D;
-} XrEventDataHardwareDisplayStateChangedEXT;
+} XrEventDataHardwareDisplayStateChangedDXR;
 
-typedef struct XrEventDataEyeTrackingStateChangedEXT {
-    XrStructureType type; // Must be XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT
+typedef struct XrEventDataEyeTrackingStateChangedDXR {
+    XrStructureType type; // Must be XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_DXR
     const void *next;
     XrSession session;
     XrBool32 isTracking;          // New derived state
-    XrEyeTrackingModeEXT activeMode; // Session's MANAGED/MANUAL preference
-} XrEventDataEyeTrackingStateChangedEXT;
+    XrEyeTrackingModeDXR activeMode; // Session's MANAGED/MANUAL preference
+} XrEventDataEyeTrackingStateChangedDXR;
 
 // --- Shared texture output rect (canvas positioning for weaver alignment) ---
-typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureOutputRectEXT)(
+typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureOutputRectDXR)(
     XrSession session, int32_t x, int32_t y, uint32_t width, uint32_t height);
 
 // --- 2D surround texture (post-weave fill of the non-canvas region) ---
-// XR_EXT_win32_window_binding spec v6 (D3D11 keyed-mutex) / v7 (D3D12 fence).
+// XR_DXR_win32_window_binding spec v6 (D3D11 keyed-mutex) / v7 (D3D12 fence).
 // The runtime blits the non-canvas pixels of the output (HWND back buffer or
 // app shared texture) from this app-supplied full-window 2D texture each frame,
 // AFTER the weave — so the surround is always at full native panel resolution.
 // Works in handle mode (runtime presents) as well as shared-texture mode;
-// requires xrSetSharedTextureOutputRectEXT to define the canvas sub-rect.
+// requires xrSetSharedTextureOutputRectDXR to define the canvas sub-rect.
 // v6: D3D11 path, IDXGIKeyedMutex sync (key 0). Pass NULL handle to clear.
 typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureSurround2DEXT)(
     XrSession session, void *sharedTextureHandle, uint32_t width, uint32_t height);
@@ -141,8 +141,8 @@ typedef XrResult (XRAPI_PTR *PFN_xrSetSharedTextureSurround2DFenceEXT)(
 // --- Readback callback (shared by macOS and Win32 bindings) ---
 typedef void (*PFN_xrReadbackCallback)(const uint8_t *pixels, uint32_t width, uint32_t height, void *userdata);
 
-// --- XR_EXT_win32_window_binding ---
-#define XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME "XR_EXT_win32_window_binding"
+// --- XR_DXR_win32_window_binding ---
+#define XR_DXR_WIN32_WINDOW_BINDING_EXTENSION_NAME "XR_DXR_win32_window_binding"
 // SPEC_VERSION 7 adds xrSetSharedTextureSurround2DFenceEXT (D3D12 fence-synced
 // 2D surround); v6 added xrSetSharedTextureSurround2DEXT (D3D11 keyed-mutex).
 // SPEC_VERSION 5 adds chromaKeyColor — runtime-side post-weave chroma-key
@@ -152,12 +152,12 @@ typedef void (*PFN_xrReadbackCallback)(const uint8_t *pixels, uint32_t width, ui
 // SPEC_VERSION 3 added sharedTextureHandle. The CreateInfo struct is unchanged
 // since v5 (surround is a separate entry-point family, not new struct fields);
 // older runtimes ignore trailing fields (struct grows at the end, ABI-safe).
-#define XR_EXT_WIN32_WINDOW_BINDING_SPEC_VERSION 7
+#define XR_DXR_WIN32_WINDOW_BINDING_SPEC_VERSION 7
 
-#define XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT ((XrStructureType)1000999001)
-#define XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT ((XrStructureType)1000999002)
+#define XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_DXR ((XrStructureType)1004999001)
+#define XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_DXR ((XrStructureType)1004999002)
 
-typedef struct XrWin32WindowBindingCreateInfoEXT {
+typedef struct XrWin32WindowBindingCreateInfoDXR {
     XrStructureType type;
     const void *next;
     void *windowHandle; // HWND
@@ -166,9 +166,9 @@ typedef struct XrWin32WindowBindingCreateInfoEXT {
     void *sharedTextureHandle; // D3D11 shared HANDLE
     XrBool32 transparentBackgroundEnabled; // SPEC_VERSION 4: opt-in BitBlt/DComp swapchain
     uint32_t chromaKeyColor; // SPEC_VERSION 5: Win32 COLORREF (0x00BBGGRR); 0 = no post-weave conversion
-} XrWin32WindowBindingCreateInfoEXT;
+} XrWin32WindowBindingCreateInfoDXR;
 
-typedef struct XrCompositionLayerWindowSpaceEXT {
+typedef struct XrCompositionLayerWindowSpaceDXR {
     XrStructureType type;
     const void *next;
     XrCompositionLayerFlags layerFlags;
@@ -178,39 +178,39 @@ typedef struct XrCompositionLayerWindowSpaceEXT {
     float width;     // Fraction of window [0..1]
     float height;    // Fraction of window [0..1]
     float disparity; // Horizontal shift, fraction of window
-} XrCompositionLayerWindowSpaceEXT;
+} XrCompositionLayerWindowSpaceDXR;
 
-// --- XR_EXT_local_3d_zone (#439/#491) ---
+// --- XR_DXR_local_3d_zone (#439/#491) ---
 // Post-weave 2D content placed at a client-window PIXEL rect, composited over
 // the woven 3D with an implicit mask (the union of Local2D layer rects implies
 // M=0 inside / M=1 elsewhere — the region under the rect goes flat 2D, "glass
-// over 3D"). Unlike XrCompositionLayerWindowSpaceEXT (fractional, disparity),
+// over 3D"). Unlike XrCompositionLayerWindowSpaceDXR (fractional, disparity),
 // the dest rect here is in post-DPI client-window pixels.
-#define XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME "XR_EXT_local_3d_zone"
-#define XR_EXT_local_3d_zone_SPEC_VERSION 1
+#define XR_DXR_LOCAL_3D_ZONE_EXTENSION_NAME "XR_DXR_local_3d_zone"
+#define XR_DXR_local_3d_zone_SPEC_VERSION 1
 
-#define XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT ((XrStructureType)1000999165)
+#define XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_DXR ((XrStructureType)1004999165)
 
-typedef struct XrCompositionLayerLocal2DEXT {
+typedef struct XrCompositionLayerLocal2DDXR {
     XrStructureType type;
     const void *next;
     XrCompositionLayerFlags layerFlags; // alpha bits honored
     XrSwapchainSubImage subImage;       // source texture + sub-rect
     XrRect2Di rect;                     // dest, client-window pixels
-} XrCompositionLayerLocal2DEXT;
+} XrCompositionLayerLocal2DDXR;
 
-// --- XR_EXT_cocoa_window_binding ---
+// --- XR_DXR_cocoa_window_binding ---
 // SPEC_VERSION 5 adds transparentBackgroundEnabled — runtime configures
 // the runtime-owned NSWindow + CAMetalLayer with isOpaque=NO so per-pixel
 // alpha from the app reaches the desktop via Cocoa per-pixel transparency.
 // sim_display_processor_metal is alpha-native — no chroma-key trick needed.
-// (Sibling of XrWin32WindowBindingCreateInfoEXT.transparentBackgroundEnabled.)
-#define XR_EXT_COCOA_WINDOW_BINDING_EXTENSION_NAME "XR_EXT_cocoa_window_binding"
-#define XR_EXT_COCOA_WINDOW_BINDING_SPEC_VERSION 5
+// (Sibling of XrWin32WindowBindingCreateInfoDXR.transparentBackgroundEnabled.)
+#define XR_DXR_COCOA_WINDOW_BINDING_EXTENSION_NAME "XR_DXR_cocoa_window_binding"
+#define XR_DXR_COCOA_WINDOW_BINDING_SPEC_VERSION 5
 
-#define XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT ((XrStructureType)1000999004)
+#define XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_DXR ((XrStructureType)1004999004)
 
-typedef struct XrCocoaWindowBindingCreateInfoEXT {
+typedef struct XrCocoaWindowBindingCreateInfoDXR {
     XrStructureType type;
     const void *next;
     void *viewHandle;                    // NSView* or NULL for offscreen
@@ -218,7 +218,7 @@ typedef struct XrCocoaWindowBindingCreateInfoEXT {
     void *readbackUserdata;
     void *sharedIOSurface;               // IOSurfaceRef for zero-copy GPU sharing
     XrBool32 transparentBackgroundEnabled; // SPEC_VERSION 5
-} XrCocoaWindowBindingCreateInfoEXT;
+} XrCocoaWindowBindingCreateInfoDXR;
 
 // --- XR_KHR_metal_enable ---
 // Hand-defined: the fetched OpenXR-SDK release-1.0.34 headers predate the
@@ -257,7 +257,7 @@ typedef XrResult(XRAPI_PTR *PFN_xrGetMetalGraphicsRequirementsKHR)(
     XrGraphicsRequirementsMetalKHR *graphicsRequirements);
 #endif // XR_TYPE_GRAPHICS_BINDING_METAL_KHR
 
-// --- XR_EXT_atlas_capture ---
+// --- XR_DXR_atlas_capture ---
 // Vendor-neutral "snapshot the runtime's composed multi-view atlas to a PNG"
 // entry point. Replaces the app-side GPU readback (AsyncGPUReadback + hidden
 // camera re-render) the plugin used to do for the screenshot ('I') key — the
@@ -265,39 +265,39 @@ typedef XrResult(XRAPI_PTR *PFN_xrGetMetalGraphicsRequirementsKHR)(
 // caller-selected stage and writes the PNG (appending
 // "_atlas_<viewCount>_<cols>x<rows>.png" to the supplied path prefix, opaque
 // alpha — DisplayXR/displayxr-runtime#425). Source of truth:
-// displayxr-runtime/src/external/openxr_includes/openxr/XR_EXT_atlas_capture.h
-#define XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME "XR_EXT_atlas_capture"
-// SPEC_VERSION 3: XrStructureType values relocated 1000999120..121 ->
-// 1000999170..171 (the old block collided with XR_EXT_workspace_file_dialog,
+// displayxr-runtime/src/external/openxr_includes/openxr/XR_DXR_atlas_capture.h
+#define XR_DXR_ATLAS_CAPTURE_EXTENSION_NAME "XR_DXR_atlas_capture"
+// SPEC_VERSION 3: XrStructureType values relocated 1004999120..121 ->
+// 1004999170..171 (the old block collided with XR_DXR_workspace_file_dialog,
 // which reserved it first). No struct/field/entry-point changes — header re-sync
 // only. Sending the stale type made the runtime reject with VALIDATION_FAILURE.
-#define XR_EXT_ATLAS_CAPTURE_SPEC_VERSION 3
+#define XR_DXR_ATLAS_CAPTURE_SPEC_VERSION 3
 
-#define XR_TYPE_ATLAS_CAPTURE_INFO_EXT ((XrStructureType)1000999170)
-#define XR_TYPE_ATLAS_CAPTURE_RESULT_EXT ((XrStructureType)1000999171)
+#define XR_TYPE_ATLAS_CAPTURE_INFO_DXR ((XrStructureType)1004999170)
+#define XR_TYPE_ATLAS_CAPTURE_RESULT_DXR ((XrStructureType)1004999171)
 
-#define XR_ATLAS_CAPTURE_PATH_MAX_EXT 256
+#define XR_ATLAS_CAPTURE_PATH_MAX_DXR 256
 
 // Values match enum mcp_capture_mode in the runtime (no translation layer):
 //   POST_COMPOSE    — atlas handed to the display processor (projection +
 //                     window-space + quad layers), end of frame.
 //   PROJECTION_ONLY — atlas with only projection-class layers, captured at the
 //                     projection-done boundary.
-typedef enum XrAtlasCaptureStageEXT {
-    XR_ATLAS_CAPTURE_STAGE_POST_COMPOSE_EXT = 0,
-    XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT = 1,
-    XR_ATLAS_CAPTURE_STAGE_MAX_ENUM_EXT = 0x7FFFFFFF
-} XrAtlasCaptureStageEXT;
+typedef enum XrAtlasCaptureStageDXR {
+    XR_ATLAS_CAPTURE_STAGE_POST_COMPOSE_DXR = 0,
+    XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_DXR = 1,
+    XR_ATLAS_CAPTURE_STAGE_MAX_ENUM_DXR = 0x7FFFFFFF
+} XrAtlasCaptureStageDXR;
 
-typedef struct XrAtlasCaptureInfoEXT {
-    XrStructureType type; // Must be XR_TYPE_ATLAS_CAPTURE_INFO_EXT
+typedef struct XrAtlasCaptureInfoDXR {
+    XrStructureType type; // Must be XR_TYPE_ATLAS_CAPTURE_INFO_DXR
     const void *next;
-    XrAtlasCaptureStageEXT stage; // Capture stage (post-compose / projection-only)
-    char pathPrefix[XR_ATLAS_CAPTURE_PATH_MAX_EXT];
-} XrAtlasCaptureInfoEXT;
+    XrAtlasCaptureStageDXR stage; // Capture stage (post-compose / projection-only)
+    char pathPrefix[XR_ATLAS_CAPTURE_PATH_MAX_DXR];
+} XrAtlasCaptureInfoDXR;
 
-typedef struct XrAtlasCaptureResultEXT {
-    XrStructureType type; // Must be XR_TYPE_ATLAS_CAPTURE_RESULT_EXT
+typedef struct XrAtlasCaptureResultDXR {
+    XrStructureType type; // Must be XR_TYPE_ATLAS_CAPTURE_RESULT_DXR
     void *next;
     uint64_t timestampNs;
     uint32_t atlasWidth;
@@ -310,49 +310,49 @@ typedef struct XrAtlasCaptureResultEXT {
     float displayHeightM;
     float eyeLeftM[3];
     float eyeRightM[3];
-} XrAtlasCaptureResultEXT;
+} XrAtlasCaptureResultDXR;
 
-typedef XrResult(XRAPI_PTR *PFN_xrCaptureAtlasEXT)(
+typedef XrResult(XRAPI_PTR *PFN_xrCaptureAtlasDXR)(
     XrSession session,
-    const XrAtlasCaptureInfoEXT *info,
-    XrAtlasCaptureResultEXT *result);
+    const XrAtlasCaptureInfoDXR *info,
+    XrAtlasCaptureResultDXR *result);
 
-// --- XR_EXT_view_rig ---
+// --- XR_DXR_view_rig ---
 // App-facing control of the runtime's view-rig (Kooima) math: chain ONE rig
 // descriptor on XrViewLocateInfo::next and consume render-ready XrView{pose,fov}
 // instead of computing the projection from raw eyes ourselves. Chain
-// XrViewDisplayRawEXT on XrViewState::next to recover the raw display-space eyes
+// XrViewDisplayRawDXR on XrViewState::next to recover the raw display-space eyes
 // (for the gizmo / eye-position cache). Descriptors carry NO clip params (near/far
 // stay app-side) and NO placement params (the runtime owns the window/canvas).
 // Per-locate: chain every frame you want it to drive; a locate chaining nothing
 // keeps the default raw-eye transport. Out-of-range values clamp (one-shot runtime
 // WARN), never reject; if both rigs are chained the camera rig wins. Source of
-// truth: displayxr-runtime/src/external/openxr_includes/openxr/XR_EXT_view_rig.h
+// truth: displayxr-runtime/src/external/openxr_includes/openxr/XR_DXR_view_rig.h
 // (SPEC_VERSION 3 — reconcile with the Khronos registry before spec freeze).
-#define XR_EXT_VIEW_RIG_EXTENSION_NAME "XR_EXT_view_rig"
-#define XR_EXT_view_rig_SPEC_VERSION 3
+#define XR_DXR_VIEW_RIG_EXTENSION_NAME "XR_DXR_view_rig"
+#define XR_DXR_view_rig_SPEC_VERSION 3
 
-#define XR_TYPE_DISPLAY_RIG_EXT ((XrStructureType)1000999140)
-#define XR_TYPE_CAMERA_RIG_EXT ((XrStructureType)1000999141)
-#define XR_TYPE_VIEW_DISPLAY_RAW_EXT ((XrStructureType)1000999142)
+#define XR_TYPE_DISPLAY_RIG_DXR ((XrStructureType)1004999140)
+#define XR_TYPE_CAMERA_RIG_DXR ((XrStructureType)1004999141)
+#define XR_TYPE_VIEW_DISPLAY_RAW_DXR ((XrStructureType)1004999142)
 
-// Capacity of XrViewDisplayRawEXT::rawEyes (matches the runtime's max views).
-#define XR_VIEW_RIG_MAX_RAW_EYES_EXT 8
+// Capacity of XrViewDisplayRawDXR::rawEyes (matches the runtime's max views).
+#define XR_VIEW_RIG_MAX_RAW_EYES_DXR 8
 
 // Display-centric rig (window/canvas as a portal). Chain on XrViewLocateInfo::next.
-typedef struct XrDisplayRigEXT {
-    XrStructureType type; // Must be XR_TYPE_DISPLAY_RIG_EXT
+typedef struct XrDisplayRigDXR {
+    XrStructureType type; // Must be XR_TYPE_DISPLAY_RIG_DXR
     const void *next;
     XrPosef pose;               // virtual display plane pose in the locate space
     float virtualDisplayHeight; // app units; m2v = this / physical canvas height
     float ipdFactor;            // [0,1] multiplies view-pose spread about center
     float parallaxFactor;       // [0,1] lerps eye centroid toward nominal viewer
     float perspectiveFactor;    // [0.1,10] scales eye XYZ (object perspective)
-} XrDisplayRigEXT;
+} XrDisplayRigDXR;
 
 // Camera-centric rig (app camera perturbed by eye tracking). Chain on next.
-typedef struct XrCameraRigEXT {
-    XrStructureType type; // Must be XR_TYPE_CAMERA_RIG_EXT
+typedef struct XrCameraRigDXR {
+    XrStructureType type; // Must be XR_TYPE_CAMERA_RIG_DXR
     const void *next;
     XrPosef pose;             // camera pose in the locate space
     float ipdFactor;          // [0,1] multiplies view-pose spread about center
@@ -363,109 +363,109 @@ typedef struct XrCameraRigEXT {
                               // The plugin already folds scene scale into
                               // convergenceDiopters (/ssz), so it passes 1.0 here to
                               // keep the runtime's pre-v3 (1 unit = 1 m) behavior.
-} XrCameraRigEXT;
+} XrCameraRigDXR;
 
 // Raw rig inputs for the locate, filled by the runtime. Chain on XrViewState::next.
 // rawEyes are verbatim physical-display-space eye positions (meters, display-center
 // origin, +X right +Y up +Z toward viewer), one per active view; NOT canvas-rebased.
-typedef struct XrViewDisplayRawEXT {
-    XrStructureType type; // Must be XR_TYPE_VIEW_DISPLAY_RAW_EXT
+typedef struct XrViewDisplayRawDXR {
+    XrStructureType type; // Must be XR_TYPE_VIEW_DISPLAY_RAW_DXR
     void *next;
-    XrVector3f rawEyes[XR_VIEW_RIG_MAX_RAW_EYES_EXT];
+    XrVector3f rawEyes[XR_VIEW_RIG_MAX_RAW_EYES_DXR];
     uint32_t eyeCountOutput;      // eyes written = the DP's per-view count
     XrPosef displayPlanePose;     // physical display plane in the locate space
     XrRect2Di canvasRectPx;       // effective canvas on the panel (client/sub-rect)
     XrExtent2Df canvasSizeMeters; // physical size of that canvas
     int64_t sampleTimeNs;         // when the eyes were sampled (monotonic)
     XrBool32 isTracking;          // physical tracker lock (vs nominal fallback)
-} XrViewDisplayRawEXT;
+} XrViewDisplayRawDXR;
 
 // Workspace-controller-only entry point — the plugin never calls this (Unity is
 // never the workspace controller); typedef kept for header completeness.
-typedef XrResult(XRAPI_PTR *PFN_xrSetWorkspaceViewRigEXT)(XrSession session, const void *rig);
+typedef XrResult(XRAPI_PTR *PFN_xrSetWorkspaceViewRigDXR)(XrSession session, const void *rig);
 
-// --- XR_EXT_display_zones ---
+// --- XR_DXR_display_zones ---
 // Compose N 3D zones (each a window-pixel rect with its own view-rig framing and
 // its own projection layer) within the window. Built BY COMPOSITION on top of
-// XR_EXT_view_rig (the rig descriptors are chained per-locate as usual) and
-// XR_EXT_local_3d_zone (the 2D zones are XrCompositionLayerLocal2DEXT). A frame
-// is a ZONES FRAME iff >= 1 projection layer carries an XrDisplayZoneEXT chain;
-// then the canvas output rect (xrSetSharedTextureOutputRectEXT) and the surround
-// path are inert. Chain the SAME XrDisplayZoneEXT instance at the locate
+// XR_DXR_view_rig (the rig descriptors are chained per-locate as usual) and
+// XR_DXR_local_3d_zone (the 2D zones are XrCompositionLayerLocal2DDXR). A frame
+// is a ZONES FRAME iff >= 1 projection layer carries an XrDisplayZoneDXR chain;
+// then the canvas output rect (xrSetSharedTextureOutputRectDXR) and the surround
+// path are inert. Chain the SAME XrDisplayZoneDXR instance at the locate
 // (XrViewLocateInfo::next, scoping the Kooima framing to the rect — the rect IS
 // the canvas) and at the submit (XrCompositionLayerProjection::next, binding the
 // layer's views into that rect). Source of truth: displayxr-runtime (and the
-// avatar's openxr_includes/openxr/XR_EXT_display_zones.h), SPEC_VERSION 1.
-#define XR_EXT_DISPLAY_ZONES_EXTENSION_NAME "XR_EXT_display_zones"
-#define XR_EXT_display_zones_SPEC_VERSION 1
+// avatar's openxr_includes/openxr/XR_DXR_display_zones.h), SPEC_VERSION 1.
+#define XR_DXR_DISPLAY_ZONES_EXTENSION_NAME "XR_DXR_display_zones"
+#define XR_DXR_display_zones_SPEC_VERSION 1
 
-#define XR_TYPE_DISPLAY_ZONE_CAPABILITIES_EXT               ((XrStructureType)1000999150)
-#define XR_TYPE_DISPLAY_ZONE_EXT                            ((XrStructureType)1000999151)
-#define XR_TYPE_DISPLAY_ZONES_FRAME_END_INFO_EXT            ((XrStructureType)1000999152)
-#define XR_TYPE_EVENT_DATA_DISPLAY_ZONE_METRICS_CHANGED_EXT ((XrStructureType)1000999153)
+#define XR_TYPE_DISPLAY_ZONE_CAPABILITIES_DXR               ((XrStructureType)1004999150)
+#define XR_TYPE_DISPLAY_ZONE_DXR                            ((XrStructureType)1004999151)
+#define XR_TYPE_DISPLAY_ZONES_FRAME_END_INFO_DXR            ((XrStructureType)1004999152)
+#define XR_TYPE_EVENT_DATA_DISPLAY_ZONE_METRICS_CHANGED_DXR ((XrStructureType)1004999153)
 
-typedef XrFlags64 XrDisplayZonesFrameEndFlagsEXT;
+typedef XrFlags64 XrDisplayZonesFrameEndFlagsDXR;
 // Cross-check zone/locate/mask consistency this frame (one-shot WARN per
 // violation class, never a per-frame error). Bring-up diagnostic only.
-#define XR_DISPLAY_ZONES_FRAME_END_VALIDATE_BIT_EXT ((XrDisplayZonesFrameEndFlagsEXT)0x00000001)
+#define XR_DISPLAY_ZONES_FRAME_END_VALIDATE_BIT_DXR ((XrDisplayZonesFrameEndFlagsDXR)0x00000001)
 
 // Capabilities of the display-zones path for a session. supported==XR_FALSE =>
 // only the legacy single-canvas path. maxZones3D = max zone-chained projection
 // layers per frame.
-typedef struct XrDisplayZoneCapabilitiesEXT {
-	XrStructureType type; // Must be XR_TYPE_DISPLAY_ZONE_CAPABILITIES_EXT
+typedef struct XrDisplayZoneCapabilitiesDXR {
+	XrStructureType type; // Must be XR_TYPE_DISPLAY_ZONE_CAPABILITIES_DXR
 	void *next;
 	XrBool32 supported;
 	uint32_t maxZones3D;
-} XrDisplayZoneCapabilitiesEXT;
+} XrDisplayZoneCapabilitiesDXR;
 
 // A 3D display zone: identity + placement. Valid at TWO chain points —
 // XrViewLocateInfo::next (zone-scoped locate, rect IS the canvas) and
 // XrCompositionLayerProjection::next (binds the layer's views to the zone at
 // xrEndFrame). Chain the SAME instance at both points within a frame; the
 // xrEndFrame values are authoritative. rect is in client-window pixels (same
-// space as XrCompositionLayerLocal2DEXT::rect). zoneId is app-chosen, unique
+// space as XrCompositionLayerLocal2DDXR::rect). zoneId is app-chosen, unique
 // among the frame's 3D zones; there is NO zone handle (zones are stateless
 // per-frame data, like layers).
-typedef struct XrDisplayZoneEXT {
-	XrStructureType type; // Must be XR_TYPE_DISPLAY_ZONE_EXT
+typedef struct XrDisplayZoneDXR {
+	XrStructureType type; // Must be XR_TYPE_DISPLAY_ZONE_DXR
 	const void *next;
 	uint32_t zoneId;
 	XrRect2Di rect; // client-window pixels
-} XrDisplayZoneEXT;
+} XrDisplayZoneDXR;
 
-// The mask handle from XR_EXT_local_3d_zone. The plugin never authors a wish
+// The mask handle from XR_DXR_local_3d_zone. The plugin never authors a wish
 // mask (it always auto-derives), so we forward-declare the handle here rather
 // than pull in the full mask-authoring API. (XR_DEFINE_HANDLE-equivalent.)
 #ifndef XR_DISPLAYXR_LOCAL3D_ZONE_MASK_DEFINED
 #define XR_DISPLAYXR_LOCAL3D_ZONE_MASK_DEFINED
-XR_DEFINE_HANDLE(XrLocal3DZoneMaskEXT)
+XR_DEFINE_HANDLE(XrLocal3DZoneMaskDXR)
 #endif
 
 // Per-frame wish reference. Optional, chained on XrFrameEndInfo::next in a zones
 // frame. Absent or wishMask==XR_NULL_HANDLE: the wish auto-derives as the union
 // of the frame's 3D-zone rects (feathered). The plugin chains this only when the
 // VALIDATE bit is requested for bring-up; otherwise nothing is chained.
-typedef struct XrDisplayZonesFrameEndInfoEXT {
-	XrStructureType type; // Must be XR_TYPE_DISPLAY_ZONES_FRAME_END_INFO_EXT
+typedef struct XrDisplayZonesFrameEndInfoDXR {
+	XrStructureType type; // Must be XR_TYPE_DISPLAY_ZONES_FRAME_END_INFO_DXR
 	const void *next;
-	XrDisplayZonesFrameEndFlagsEXT flags;
-	XrLocal3DZoneMaskEXT wishMask; // XR_NULL_HANDLE = auto-derive
-} XrDisplayZonesFrameEndInfoEXT;
+	XrDisplayZonesFrameEndFlagsDXR flags;
+	XrLocal3DZoneMaskDXR wishMask; // XR_NULL_HANDLE = auto-derive
+} XrDisplayZonesFrameEndInfoDXR;
 
 // Advisory: per-zone recommended view sizes may have changed (display-mode /
 // tile-count switch, DPI change). Re-query each zone via
-// xrGetDisplayZoneRecommendedViewSizeEXT; stale sizes stay correct, just soft.
-typedef struct XrEventDataDisplayZoneMetricsChangedEXT {
-	XrStructureType type; // Must be XR_TYPE_EVENT_DATA_DISPLAY_ZONE_METRICS_CHANGED_EXT
+// xrGetDisplayZoneRecommendedViewSizeDXR; stale sizes stay correct, just soft.
+typedef struct XrEventDataDisplayZoneMetricsChangedDXR {
+	XrStructureType type; // Must be XR_TYPE_EVENT_DATA_DISPLAY_ZONE_METRICS_CHANGED_DXR
 	const void *next;
 	XrSession session;
-} XrEventDataDisplayZoneMetricsChangedEXT;
+} XrEventDataDisplayZoneMetricsChangedDXR;
 
-typedef XrResult(XRAPI_PTR *PFN_xrGetDisplayZoneCapabilitiesEXT)(
-    XrSession session, XrDisplayZoneCapabilitiesEXT *capabilities);
+typedef XrResult(XRAPI_PTR *PFN_xrGetDisplayZoneCapabilitiesDXR)(
+    XrSession session, XrDisplayZoneCapabilitiesDXR *capabilities);
 
-typedef XrResult(XRAPI_PTR *PFN_xrGetDisplayZoneRecommendedViewSizeEXT)(
+typedef XrResult(XRAPI_PTR *PFN_xrGetDisplayZoneRecommendedViewSizeDXR)(
     XrSession session, const XrRect2Di *zoneRect, XrExtent2Di *recommendedViewSize);
 
 #ifdef __cplusplus

--- a/native~/displayxr_local2d.h
+++ b/native~/displayxr_local2d.h
@@ -3,7 +3,7 @@
 //
 // Local2D overlay (#439/#491).
 //
-// Routes a Unity RenderTexture through to an XrCompositionLayerLocal2DEXT
+// Routes a Unity RenderTexture through to an XrCompositionLayerLocal2DDXR
 // composition layer so the runtime composites it "glass over 3D" — the woven
 // 3D under the layer's pixel rect goes flat 2D (implicit mask) and the 2D
 // content is alpha-composited on top.
@@ -41,7 +41,7 @@ DISPLAYXR_EXPORT void displayxr_local2d_set_texture(void *unity_native_tex,
                                                     int width, int height);
 
 // Set the destination rect in client-window PIXELS (post-DPI), matching the
-// XrCompositionLayerLocal2DEXT::rect / mask-tier coordinate space.
+// XrCompositionLayerLocal2DDXR::rect / mask-tier coordinate space.
 DISPLAYXR_EXPORT void displayxr_local2d_set_rect(int x, int y, int width, int height);
 
 // Disable the layer (stops submitting it this frame onward).

--- a/native~/displayxr_native_shared.cpp
+++ b/native~/displayxr_native_shared.cpp
@@ -139,8 +139,8 @@ displayxr_set_viewport_size_native(uint32_t width, uint32_t height,
 // (displayxr_set_canvas_rect) was re-homed out of the deleted hook TU — without it
 // the accessor returns 0 (full-window), the mask is stamped full-window while the
 // zone is woven into the sub-rect, and the mask CLIPS the woven content (#166).
-// The hook-era output-rect apply (xrSetSharedTextureOutputRectEXT) is dropped: the
-// provider drives the zone weave via XrDisplayZoneEXT (dxr_prov_set_3d_zone_rect),
+// The hook-era output-rect apply (xrSetSharedTextureOutputRectDXR) is dropped: the
+// provider drives the zone weave via XrDisplayZoneDXR (dxr_prov_set_3d_zone_rect),
 // so this setter only needs to update the shared canvas rect the mask path reads.
 static int s_canvas_rect_valid = 0;
 static int32_t s_canvas_rect_x = 0, s_canvas_rect_y = 0;

--- a/native~/displayxr_shared_state.h
+++ b/native~/displayxr_shared_state.h
@@ -66,7 +66,7 @@ typedef struct DisplayXREyePositions {
 } DisplayXREyePositions;
 
 // --- Kooima canvas (#189) — the window as the runtime frames Kooima into it ---
-// The XR_EXT_view_rig raw channel (XrViewDisplayRawEXT) reports the effective
+// The XR_DXR_view_rig raw channel (XrViewDisplayRawDXR) reports the effective
 // canvas the runtime uses for the window-relative off-axis projection each
 // frame: its rect ON THE PANEL (panel pixels, top-left origin) and its physical
 // size (meters). The provider publishes it so the editor Scene-view gizmo can
@@ -97,7 +97,7 @@ typedef struct DisplayXRStereoMatrices {
 // --- Window-space layer descriptor ---
 // Vestigial: formerly filled by the OpenXR-hook path's wsui pre-end-frame and
 // consumed in hooked_xrEndFrame. That path was removed in the Task-3 hook-backend
-// cleanup (#166); the provider builds its own XrCompositionLayerWindowSpaceEXT in
+// cleanup (#166); the provider builds its own XrCompositionLayerWindowSpaceDXR in
 // displayxr_provider_session.cpp (ps_submit_wsui). Retained for a possible future
 // follow-up removal (see the epic plan) — no live reader/writer today.
 
@@ -116,7 +116,7 @@ typedef struct DisplayXRWindowLayer {
 // client-window PIXEL rect, composited "glass over 3D" via the runtime's
 // implicit mask. Vestigial like DisplayXRWindowLayer above: formerly filled by
 // the removed hook path; the provider now submits its own
-// XrCompositionLayerLocal2DEXT (ps_submit_local2d). Retained pending a future
+// XrCompositionLayerLocal2DDXR (ps_submit_local2d). Retained pending a future
 // follow-up removal.
 typedef struct DisplayXRLocal2DLayer {
     XrSwapchain swapchain;      // Overlay swapchain handle
@@ -168,7 +168,7 @@ typedef struct DisplayXRState {
 
     // Transparent background opt-in (issue runtime-pvt #191, displayxr-unity#57).
     // Set from C# at SubsystemRegistration before xrCreateSession; consumed
-    // when constructing XrWin32WindowBindingCreateInfoEXT to request the
+    // when constructing XrWin32WindowBindingCreateInfoDXR to request the
     // runtime's BitBlt (D3D11) or DComp (D3D12) swapchain path.
     uint8_t transparent_background_requested;
 
@@ -200,7 +200,7 @@ typedef struct DisplayXRState {
     uint8_t has_display_mode_ext;
 
     // Function pointers for display mode switching
-    PFN_xrRequestDisplayModeEXT pfn_request_display_mode;
+    PFN_xrRequestDisplayModeDXR pfn_request_display_mode;
 } DisplayXRState;
 
 // Get the global shared state singleton.

--- a/native~/displayxr_standalone.cpp
+++ b/native~/displayxr_standalone.cpp
@@ -38,7 +38,7 @@ extern "C" int dxr_prov_request_rendering_mode(uint32_t mode_index);
 // Accessors on the GraphicsBackend opaque class — defined as a thin wrapper
 // in displayxr_hooks.cpp so we don't need the full class definition here.
 uint32_t displayxr_hooked_get_rendering_mode_count(GraphicsBackend *b);
-const XrDisplayRenderingModeInfoEXT *displayxr_hooked_get_rendering_modes(GraphicsBackend *b);
+const XrDisplayRenderingModeInfoDXR *displayxr_hooked_get_rendering_modes(GraphicsBackend *b);
 XrResult displayxr_hooked_request_rendering_mode(GraphicsBackend *b, XrSession s, uint32_t mode_index);
 
 // ============================================================================
@@ -115,8 +115,8 @@ typedef struct StandaloneState {
 	SASwapchain atlas;
 	int atlas_created;
 
-	// Rendering mode metadata (from xrEnumerateDisplayRenderingModesEXT)
-	XrDisplayRenderingModeInfoEXT rendering_modes[SA_MAX_RENDERING_MODES];
+	// Rendering mode metadata (from xrEnumerateDisplayRenderingModesDXR)
+	XrDisplayRenderingModeInfoDXR rendering_modes[SA_MAX_RENDERING_MODES];
 	uint32_t rendering_mode_count;
 	uint32_t current_rendering_mode_index;
 
@@ -124,11 +124,11 @@ typedef struct StandaloneState {
 	float eye_positions[SA_MAX_VIEWS][3];
 	uint32_t located_view_count;
 
-	// XR_EXT_view_rig (#396): when the runtime advertises the extension, the
+	// XR_DXR_view_rig (#396): when the runtime advertises the extension, the
 	// frame locate chains a rig descriptor and the runtime returns render-ready
 	// per-view pose+fov (Kooima done runtime-side). compute_views then builds
 	// matrices from these instead of running display3d/camera3d locally.
-	int has_view_rig;                    // runtime advertises XR_EXT_view_rig
+	int has_view_rig;                    // runtime advertises XR_DXR_view_rig
 	int rig_views_valid;                 // begin_frame filled rig_view_* this frame
 	XrPosef rig_view_pose[SA_MAX_VIEWS]; // render-ready per-view pose
 	XrFovf rig_view_fov[SA_MAX_VIEWS];   // render-ready per-view fov
@@ -166,10 +166,10 @@ typedef struct StandaloneState {
 	PFN_xrReleaseSwapchainImage pfn_release_swapchain_image;
 
 	// Display mode extensions (optional — resolved after instance creation)
-	PFN_xrRequestDisplayModeEXT pfn_request_display_mode;
-	PFN_xrRequestDisplayRenderingModeEXT pfn_request_rendering_mode;
-	PFN_xrEnumerateDisplayRenderingModesEXT pfn_enumerate_rendering_modes;
-	PFN_xrSetSharedTextureOutputRectEXT pfn_set_output_rect;
+	PFN_xrRequestDisplayModeDXR pfn_request_display_mode;
+	PFN_xrRequestDisplayRenderingModeDXR pfn_request_rendering_mode;
+	PFN_xrEnumerateDisplayRenderingModesDXR pfn_enumerate_rendering_modes;
+	PFN_xrSetSharedTextureOutputRectDXR pfn_set_output_rect;
 	PFN_xrSetSharedTextureSurround2DFenceEXT pfn_set_surround_fence;
 	uint32_t canvas_width;
 	uint32_t canvas_height;
@@ -371,25 +371,25 @@ resolve_functions(void)
 	// Optional display mode extensions (don't fail if missing)
 	{
 		PFN_xrVoidFunction fn = NULL;
-		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrRequestDisplayModeEXT", &fn)) && fn) {
-			s_sa.pfn_request_display_mode = (PFN_xrRequestDisplayModeEXT)fn;
+		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrRequestDisplayModeDXR", &fn)) && fn) {
+			s_sa.pfn_request_display_mode = (PFN_xrRequestDisplayModeDXR)fn;
 			s_sa.has_display_mode_ext = 1;
-			sa_log("[DisplayXR-SA] Resolved xrRequestDisplayModeEXT\n");
+			sa_log("[DisplayXR-SA] Resolved xrRequestDisplayModeDXR\n");
 		}
 		fn = NULL;
-		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrRequestDisplayRenderingModeEXT", &fn)) && fn) {
-			s_sa.pfn_request_rendering_mode = (PFN_xrRequestDisplayRenderingModeEXT)fn;
-			sa_log("[DisplayXR-SA] Resolved xrRequestDisplayRenderingModeEXT\n");
+		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrRequestDisplayRenderingModeDXR", &fn)) && fn) {
+			s_sa.pfn_request_rendering_mode = (PFN_xrRequestDisplayRenderingModeDXR)fn;
+			sa_log("[DisplayXR-SA] Resolved xrRequestDisplayRenderingModeDXR\n");
 		}
 		fn = NULL;
-		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrEnumerateDisplayRenderingModesEXT", &fn)) && fn) {
-			s_sa.pfn_enumerate_rendering_modes = (PFN_xrEnumerateDisplayRenderingModesEXT)fn;
-			sa_log("[DisplayXR-SA] Resolved xrEnumerateDisplayRenderingModesEXT\n");
+		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrEnumerateDisplayRenderingModesDXR", &fn)) && fn) {
+			s_sa.pfn_enumerate_rendering_modes = (PFN_xrEnumerateDisplayRenderingModesDXR)fn;
+			sa_log("[DisplayXR-SA] Resolved xrEnumerateDisplayRenderingModesDXR\n");
 		}
 		fn = NULL;
-		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrSetSharedTextureOutputRectEXT", &fn)) && fn) {
-			s_sa.pfn_set_output_rect = (PFN_xrSetSharedTextureOutputRectEXT)fn;
-			sa_log("[DisplayXR-SA] Resolved xrSetSharedTextureOutputRectEXT\n");
+		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrSetSharedTextureOutputRectDXR", &fn)) && fn) {
+			s_sa.pfn_set_output_rect = (PFN_xrSetSharedTextureOutputRectDXR)fn;
+			sa_log("[DisplayXR-SA] Resolved xrSetSharedTextureOutputRectDXR\n");
 		}
 		fn = nullptr;
 		if (XR_SUCCEEDED(s_sa.gipa(s_sa.instance, "xrSetSharedTextureSurround2DFenceEXT", &fn)) && fn) {
@@ -419,7 +419,7 @@ enumerate_and_store_modes(void)
 
 	if (total > SA_MAX_RENDERING_MODES) total = SA_MAX_RENDERING_MODES;
 	for (uint32_t i = 0; i < total; i++) {
-		s_sa.rendering_modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT;
+		s_sa.rendering_modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_DXR;
 		s_sa.rendering_modes[i].next = NULL;
 	}
 
@@ -443,7 +443,7 @@ enumerate_and_store_modes(void)
 }
 
 /// Get the current rendering mode info. Returns NULL if no modes enumerated.
-static const XrDisplayRenderingModeInfoEXT *
+static const XrDisplayRenderingModeInfoDXR *
 get_current_mode(void)
 {
 	for (uint32_t i = 0; i < s_sa.rendering_mode_count; i++) {
@@ -455,7 +455,7 @@ get_current_mode(void)
 
 /// Get tiling parameters for a rendering mode (or defaults if NULL).
 static void
-get_mode_tiling(const XrDisplayRenderingModeInfoEXT *mode,
+get_mode_tiling(const XrDisplayRenderingModeInfoDXR *mode,
                 uint32_t *view_count, uint32_t *tile_cols, uint32_t *tile_rows,
                 uint32_t *view_w, uint32_t *view_h)
 {
@@ -485,7 +485,7 @@ get_mode_tiling(const XrDisplayRenderingModeInfoEXT *mode,
 // if canvas is not set. Used for actual rendering; get_mode_tiling (above)
 // is used for worst-case atlas/swapchain sizing.
 static void
-get_render_tiling(const XrDisplayRenderingModeInfoEXT *mode,
+get_render_tiling(const XrDisplayRenderingModeInfoDXR *mode,
                   uint32_t *view_count, uint32_t *tile_cols, uint32_t *tile_rows,
                   uint32_t *view_w, uint32_t *view_h)
 {
@@ -660,7 +660,7 @@ destroy_atlas_swapchain(void)
 
 
 #if defined(_WIN32)
-// Push the canvas rect to the runtime via xrSetSharedTextureOutputRectEXT.
+// Push the canvas rect to the runtime via xrSetSharedTextureOutputRectDXR.
 // canvas_offset_x/y are WINDOW-RELATIVE (offset within the client area),
 // not screen-relative — the SR weaver adds these to its own window position
 // when computing phase alignment. Since our canvas IS the full window with
@@ -1069,7 +1069,7 @@ displayxr_standalone_start(const char *runtime_json_path)
 	if (s_unity_gfx_api == 21 /* Vulkan */) win_gfx_enable = "XR_KHR_vulkan_enable";
 #endif
 #endif
-	// XR_EXT_view_rig (#396): probe availability BEFORE requesting it — older
+	// XR_DXR_view_rig (#396): probe availability BEFORE requesting it — older
 	// runtimes reject an unknown extension at xrCreateInstance. Only enable it
 	// when advertised; otherwise the SA path falls back to the legacy local
 	// Kooima compute in compute_views (see the has_view_rig gate there).
@@ -1090,7 +1090,7 @@ displayxr_standalone_start(const char *runtime_json_path)
 				if (XR_SUCCEEDED(enum_ext(NULL, avail, &avail, props))) {
 					for (uint32_t i = 0; i < avail; i++) {
 						if (strcmp(props[i].extensionName,
-						           XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0) {
+						           XR_DXR_VIEW_RIG_EXTENSION_NAME) == 0) {
 							s_sa.has_view_rig = 1;
 							break;
 						}
@@ -1099,23 +1099,23 @@ displayxr_standalone_start(const char *runtime_json_path)
 				free(props);
 			}
 		}
-		sa_log("[DisplayXR-SA] XR_EXT_view_rig: %s\n",
+		sa_log("[DisplayXR-SA] XR_DXR_view_rig: %s\n",
 		       s_sa.has_view_rig ? "AVAILABLE (runtime owns Kooima)"
 		                         : "not found (legacy local Kooima path)");
 	}
 
 	const char *extensions[8];
 	uint32_t ext_count = 0;
-	extensions[ext_count++] = XR_EXT_DISPLAY_INFO_EXTENSION_NAME;
+	extensions[ext_count++] = XR_DXR_DISPLAY_INFO_EXTENSION_NAME;
 #if defined(__APPLE__)
 	extensions[ext_count++] = XR_KHR_METAL_ENABLE_EXTENSION_NAME;
-	extensions[ext_count++] = XR_EXT_COCOA_WINDOW_BINDING_EXTENSION_NAME;
+	extensions[ext_count++] = XR_DXR_COCOA_WINDOW_BINDING_EXTENSION_NAME;
 #elif defined(_WIN32)
 	extensions[ext_count++] = win_gfx_enable;
-	extensions[ext_count++] = XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME;
+	extensions[ext_count++] = XR_DXR_WIN32_WINDOW_BINDING_EXTENSION_NAME;
 #endif
 	if (s_sa.has_view_rig)
-		extensions[ext_count++] = XR_EXT_VIEW_RIG_EXTENSION_NAME;
+		extensions[ext_count++] = XR_DXR_VIEW_RIG_EXTENSION_NAME;
 
 	PFN_xrVoidFunction fn_create = NULL;
 	s_sa.gipa(XR_NULL_HANDLE, "xrCreateInstance", &fn_create);
@@ -1171,8 +1171,8 @@ displayxr_standalone_start(const char *runtime_json_path)
 	}
 
 	// --- Step 6: Get system properties + display info ---
-	XrDisplayInfoEXT display_info_ext = {};
-	display_info_ext.type = XR_TYPE_DISPLAY_INFO_EXT;
+	XrDisplayInfoDXR display_info_ext = {};
+	display_info_ext.type = XR_TYPE_DISPLAY_INFO_DXR;
 
 	XrSystemProperties sys_props = {XR_TYPE_SYSTEM_PROPERTIES};
 	sys_props.next = &display_info_ext;
@@ -1274,8 +1274,8 @@ displayxr_standalone_start(const char *runtime_json_path)
 	}
 
 	// Cocoa window binding (plugin-owned preview window)
-	XrCocoaWindowBindingCreateInfoEXT mac_binding = {};
-	mac_binding.type = XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT;
+	XrCocoaWindowBindingCreateInfoDXR mac_binding = {};
+	mac_binding.type = XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_DXR;
 	mac_binding.viewHandle = displayxr_sa_metal_get_view();
 	mac_binding.readbackCallback = NULL;
 	mac_binding.readbackUserdata = NULL;
@@ -1288,8 +1288,8 @@ displayxr_standalone_start(const char *runtime_json_path)
 	// Win32 window binding — identical for both graphics APIs. The runtime
 	// composites the woven output directly into this plugin-owned HWND.
 	// Declared at function scope so it outlives the xrCreateSession call below.
-	XrWin32WindowBindingCreateInfoEXT win_binding = {};
-	win_binding.type = XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT;
+	XrWin32WindowBindingCreateInfoDXR win_binding = {};
+	win_binding.type = XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_DXR;
 	win_binding.windowHandle = (void *)s_sa.preview_hwnd;
 	win_binding.readbackCallback = NULL;
 	win_binding.readbackUserdata = NULL;
@@ -1549,13 +1549,13 @@ displayxr_standalone_begin_frame(int *should_render)
 		XrViewState view_state = {XR_TYPE_VIEW_STATE};
 		uint32_t view_count = 0;
 
-		// XR_EXT_view_rig (#396): chain a rig descriptor so the runtime returns
+		// XR_DXR_view_rig (#396): chain a rig descriptor so the runtime returns
 		// render-ready XrView{pose,fov}, and chain the raw channel to recover the
 		// raw display-space eyes (for the gizmo / eye cache). The runtime owns the
-		// window/canvas resolve (we pushed it via xrSetSharedTextureOutputRectEXT).
-		XrDisplayRigEXT display_rig = {XR_TYPE_DISPLAY_RIG_EXT};
-		XrCameraRigEXT camera_rig = {XR_TYPE_CAMERA_RIG_EXT};
-		XrViewDisplayRawEXT raw_probe = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+		// window/canvas resolve (we pushed it via xrSetSharedTextureOutputRectDXR).
+		XrDisplayRigDXR display_rig = {XR_TYPE_DISPLAY_RIG_DXR};
+		XrCameraRigDXR camera_rig = {XR_TYPE_CAMERA_RIG_DXR};
+		XrViewDisplayRawDXR raw_probe = {XR_TYPE_VIEW_DISPLAY_RAW_DXR};
 		XrPosef rig_pose = s_sa.display_pose_set
 			? s_sa.display_pose
 			: XrPosef{{0, 0, 0, 1}, {0, 0, 0}};
@@ -1681,7 +1681,7 @@ displayxr_standalone_submit_frame_atlas(void *atlas_tex)
 	s_sa.pfn_release_swapchain_image(s_sa.atlas.handle, &rel_info);
 
 	// Get current mode tiling parameters (canvas-aware render dims)
-	const XrDisplayRenderingModeInfoEXT *mode = get_current_mode();
+	const XrDisplayRenderingModeInfoDXR *mode = get_current_mode();
 	uint32_t eye_count, tile_cols, tile_rows, view_w, view_h;
 	get_render_tiling(mode, &eye_count, &tile_cols, &tile_rows, &view_w, &view_h);
 
@@ -1755,7 +1755,7 @@ displayxr_standalone_submit_frame_atlas(void *atlas_tex)
 	// Window-space UI overlay (issue #67). Lazily creates an overlay
 	// swapchain on this session, copies Unity's RT into it, and fills
 	// hud_layer if a Unity texture is registered.
-	XrCompositionLayerWindowSpaceEXT hud_layer = {};
+	XrCompositionLayerWindowSpaceDXR hud_layer = {};
 	WsuiStandaloneFns wsui_fns = {
 		s_sa.pfn_enumerate_swapchain_formats,
 		s_sa.pfn_create_swapchain,
@@ -1834,7 +1834,7 @@ displayxr_standalone_end_frame_empty(void)
 
 
 // ============================================================================
-// XR_EXT_view_rig (#396): render-ready XrView{pose,fov} -> renderer matrices.
+// XR_DXR_view_rig (#396): render-ready XrView{pose,fov} -> renderer matrices.
 // Ported verbatim from the runtime reference app
 // (test_apps/cube_handle_d3d11_win/main.cpp): same convention the displayxr::math
 // rigs emit, so RenderEyeToAtlas's existing Z-flip / proj-Y-flip stay correct.
@@ -1902,7 +1902,7 @@ displayxr_standalone_compute_views(
 	s_sa.last_near_z = near_z;
 	s_sa.last_far_z = far_z;
 
-	// XR_EXT_view_rig (#396): the runtime already returned render-ready per-view
+	// XR_DXR_view_rig (#396): the runtime already returned render-ready per-view
 	// pose+fov this frame (window/canvas resolve + Kooima done runtime-side).
 	// Build the renderer matrices straight from them; the legacy display3d /
 	// camera3d compute below is the fallback for runtimes without the extension.
@@ -1925,13 +1925,13 @@ displayxr_standalone_compute_views(
 		return;
 	}
 
-	// XR_EXT_view_rig (#396 W7): no rig views this frame => the runtime lacks the
+	// XR_DXR_view_rig (#396 W7): no rig views this frame => the runtime lacks the
 	// extension (or the locate failed). There is NO local Kooima fallback — signal
 	// "no views" so the caller skips the eye render. One-shot WARN.
 	static int s_sa_no_rig_warned = 0;
 	if (!s_sa_no_rig_warned) {
 		s_sa_no_rig_warned = 1;
-		sa_log("[DisplayXR-SA] compute_views: runtime lacks XR_EXT_view_rig — "
+		sa_log("[DisplayXR-SA] compute_views: runtime lacks XR_DXR_view_rig — "
 		       "no stereo views produced. Update the DisplayXR runtime.\n");
 	}
 	*valid = 0;
@@ -1950,7 +1950,7 @@ displayxr_standalone_get_current_mode_info(
 	float *view_scale_x, float *view_scale_y,
 	int *hardware_display_3d)
 {
-	const XrDisplayRenderingModeInfoEXT *mode = get_current_mode();
+	const XrDisplayRenderingModeInfoDXR *mode = get_current_mode();
 	uint32_t vc, tc, tr, vw, vh;
 	get_render_tiling(mode, &vc, &tc, &tr, &vw, &vh);
 
@@ -2440,7 +2440,7 @@ displayxr_standalone_request_display_mode(int mode_3d)
 	    s_sa.session == XR_NULL_HANDLE)
 		return 0;
 
-	XrDisplayModeEXT mode = mode_3d ? XR_DISPLAY_MODE_3D_EXT : XR_DISPLAY_MODE_2D_EXT;
+	XrDisplayModeDXR mode = mode_3d ? XR_DISPLAY_MODE_3D_DXR : XR_DISPLAY_MODE_2D_DXR;
 	XrResult result = s_sa.pfn_request_display_mode(s_sa.session, mode);
 	sa_log("[DisplayXR-SA] RequestDisplayMode(%s) → %d\n",
 		mode_3d ? "3D" : "2D", result);
@@ -2454,7 +2454,7 @@ displayxr_standalone_request_display_mode(int mode_3d)
 // backend's modes. Returns count via *out_count and the pointer to the
 // modes array via *out_modes.
 static void pick_rendering_modes_source(
-	const XrDisplayRenderingModeInfoEXT **out_modes,
+	const XrDisplayRenderingModeInfoDXR **out_modes,
 	uint32_t *out_count)
 {
 	if (s_sa.session != XR_NULL_HANDLE && s_sa.rendering_mode_count > 0) {
@@ -2487,7 +2487,7 @@ displayxr_standalone_get_rendering_mode_name(uint32_t array_slot, char *buffer, 
 	// flat byte buffer + capacity and parse a null-terminated UTF-8 string out.
 	if (!buffer || buffer_size == 0) return 0;
 	buffer[0] = '\0';
-	const XrDisplayRenderingModeInfoEXT *modes = nullptr;
+	const XrDisplayRenderingModeInfoDXR *modes = nullptr;
 	uint32_t total = 0;
 	pick_rendering_modes_source(&modes, &total);
 	if (modes == nullptr || array_slot >= total) return 0;
@@ -2543,7 +2543,7 @@ displayxr_standalone_enumerate_rendering_modes(
 	float *view_scale_x, float *view_scale_y,
 	int *hardware_display_3d)
 {
-	const XrDisplayRenderingModeInfoEXT *modes = nullptr;
+	const XrDisplayRenderingModeInfoDXR *modes = nullptr;
 	uint32_t total = 0;
 	pick_rendering_modes_source(&modes, &total);
 

--- a/native~/displayxr_standalone_internal.h
+++ b/native~/displayxr_standalone_internal.h
@@ -12,7 +12,7 @@
 
 #include <openxr/openxr.h>
 
-// XR_EXT_view_rig (#396 W7): the SA session delegates Kooima to the runtime, so it
+// XR_DXR_view_rig (#396 W7): the SA session delegates Kooima to the runtime, so it
 // no longer links displayxr::math. These local containers replace the former
 // Display3DTunables / Display3DView (data only — no math).
 typedef struct SaTunables {

--- a/native~/displayxr_standalone_vulkan.cpp
+++ b/native~/displayxr_standalone_vulkan.cpp
@@ -5,7 +5,7 @@
 //
 // The standalone session renders on its OWN Vulkan device (matching the Unity
 // editor's Vulkan API) and the runtime composites the woven 3D into the native
-// preview HWND via XR_EXT_win32_window_binding. The Unity->SA atlas upload uses
+// preview HWND via XR_DXR_win32_window_binding. The Unity->SA atlas upload uses
 // a cross-device external-memory bridge:
 //
 //   eye cameras -> s_AtlasRT (Unity VkDevice)

--- a/native~/displayxr_window_space_ui.h
+++ b/native~/displayxr_window_space_ui.h
@@ -3,7 +3,7 @@
 //
 // Window-space UI overlay (issue #67).
 //
-// Routes a Unity Canvas RenderTexture through to a XrCompositionLayerWindowSpaceEXT
+// Routes a Unity Canvas RenderTexture through to a XrCompositionLayerWindowSpaceDXR
 // composition layer so the runtime composites it on top of the eye projection.
 //
 // C# registers the pending Unity texture + fractional layer placement via the C

--- a/native~/displayxr_xrprovider/displayxr_display_provider.cpp
+++ b/native~/displayxr_xrprovider/displayxr_display_provider.cpp
@@ -1049,7 +1049,7 @@ LifecycleStart(UnitySubsystemHandle handle, void *userData)
 	// thread, deadlocks: the input queues join while the main thread waits on
 	// GfxStart.) GfxStart binds the runtime to s_overlay_hwnd.
 #ifndef _WIN32
-	// macOS: bind the runtime's weave to an NSView (via XrCocoaWindowBindingCreateInfoEXT).
+	// macOS: bind the runtime's weave to an NSView (via XrCocoaWindowBindingCreateInfoDXR).
 	// Two shapes, both on the MAIN thread (AppKit windows can't be created off-main; and
 	// the runtime's own self-host NSWindow-create inside xrCreateSession — GfxStart =
 	// render thread while the main thread blocks in GfxStart — deadlocks; the macOS

--- a/native~/displayxr_xrprovider/displayxr_provider_session.cpp
+++ b/native~/displayxr_xrprovider/displayxr_provider_session.cpp
@@ -231,12 +231,12 @@ typedef struct ProviderSession {
 
 	int has_view_rig;
 
-	// XR_EXT_atlas_capture (#140): app-facing atlas screenshot (the 'I' key /
+	// XR_DXR_atlas_capture (#140): app-facing atlas screenshot (the 'I' key /
 	// DisplayXRScreenshot). Detected in the probe, enabled on the instance, PFN
 	// soft-resolved. Re-derived each session create — no reset preservation needed.
 	int has_atlas_capture;
 
-	// XR_EXT_display_zones + XR_EXT_local_3d_zone (#166 Phase B). Detected in
+	// XR_DXR_display_zones + XR_DXR_local_3d_zone (#166 Phase B). Detected in
 	// session_start (probe) and enabled on the instance. Caps queried lazily on the
 	// first frame a zone rect is set (needs a live session). zone_caps_ok: -1 untried,
 	// 0 unsupported, 1 supported (maxZones3D>=1).
@@ -244,11 +244,11 @@ typedef struct ProviderSession {
 	int has_local_3d_zone;
 	int zone_caps_ok;
 	uint32_t zone_max_3d;
-	PFN_xrGetDisplayZoneCapabilitiesEXT       pfn_get_zone_caps;
-	PFN_xrGetDisplayZoneRecommendedViewSizeEXT pfn_get_zone_view_size;
+	PFN_xrGetDisplayZoneCapabilitiesDXR       pfn_get_zone_caps;
+	PFN_xrGetDisplayZoneRecommendedViewSizeDXR pfn_get_zone_view_size;
 
 	// App-supplied single 3D-zone rect (client-window px, top-left origin). When
-	// valid + caps OK, the locate hook chains XrDisplayZoneEXT before the rig
+	// valid + caps OK, the locate hook chains XrDisplayZoneDXR before the rig
 	// (zone-scoped Kooima) and submit chains the same zone on the projection layer,
 	// and the swapchain is sized to the zone's recommended view size. w<=0||h<=0
 	// clears (full-window framing = the Phase A path). (Single-zone first;
@@ -389,7 +389,7 @@ typedef struct ProviderSession {
 	DxrProvDisplayInfo display_info;
 
 	// Rendering modes
-	XrDisplayRenderingModeInfoEXT modes[PS_MAX_RENDERING_MODES];
+	XrDisplayRenderingModeInfoDXR modes[PS_MAX_RENDERING_MODES];
 	uint32_t mode_count;
 
 	// SPI swapchain. arraySize is ALWAYS 2 (Unity's stereo topology is fixed at
@@ -464,9 +464,9 @@ typedef struct ProviderSession {
 	XrSwapchainImageMetalKHR wsui_images_metal[PS_MAX_SWAPCHAIN_IMAGES];
 #endif // _WIN32
 
-	// Local2D layer (#166 Phase B, XR_EXT_local_3d_zone) — post-weave 2D content at a
+	// Local2D layer (#166 Phase B, XR_DXR_local_3d_zone) — post-weave 2D content at a
 	// client-window PIXEL rect (the 2D band). Same cross-device-bridge shape as wsui,
-	// but submitted as XrCompositionLayerLocal2DEXT with a pixel rect (not fractional).
+	// but submitted as XrCompositionLayerLocal2DDXR with a pixel rect (not fractional).
 	XrSwapchain l2d_swapchain;
 	uint32_t    l2d_w, l2d_h, l2d_image_count;
 	int64_t     l2d_format;
@@ -536,11 +536,11 @@ typedef struct ProviderSession {
 	PFN_xrEndSession                  pfn_end_session;
 	PFN_xrDestroyInstance             pfn_destroy_instance;
 	PFN_xrEnumerateEnvironmentBlendModes    pfn_enumerate_blend_modes;    // transparency
-	PFN_xrEnumerateDisplayRenderingModesEXT pfn_enumerate_modes;          // optional
-	PFN_xrRequestDisplayRenderingModeEXT    pfn_request_rendering_mode;   // optional
-	PFN_xrRequestDisplayModeEXT             pfn_request_display_mode;     // optional
-	PFN_xrRequestEyeTrackingModeEXT         pfn_request_eye_tracking_mode;// optional
-	PFN_xrCaptureAtlasEXT                    pfn_capture_atlas;            // #140, optional
+	PFN_xrEnumerateDisplayRenderingModesDXR pfn_enumerate_modes;          // optional
+	PFN_xrRequestDisplayRenderingModeDXR    pfn_request_rendering_mode;   // optional
+	PFN_xrRequestDisplayModeDXR             pfn_request_display_mode;     // optional
+	PFN_xrRequestEyeTrackingModeDXR         pfn_request_eye_tracking_mode;// optional
+	PFN_xrCaptureAtlasDXR                    pfn_capture_atlas;            // #140, optional
 } ProviderSession;
 
 static ProviderSession s_ps;
@@ -714,32 +714,32 @@ static int ps_resolve_functions(void)
 	PS_RESOLVE("xrEndSession", pfn_end_session, PFN_xrEndSession);
 	PS_RESOLVE("xrDestroyInstance", pfn_destroy_instance, PFN_xrDestroyInstance);
 	PS_RESOLVE("xrEnumerateEnvironmentBlendModes", pfn_enumerate_blend_modes, PFN_xrEnumerateEnvironmentBlendModes);
-	// Optional EXT (XR_EXT_display_info mode/eye-tracking control) — soft-resolve;
+	// Optional EXT (XR_DXR_display_info mode/eye-tracking control) — soft-resolve;
 	// OK if absent (older runtime → the C# mode UI/events simply stay inert).
 	{
 		PFN_xrVoidFunction _fn = NULL;
-		s_ps.gipa(s_ps.instance, "xrEnumerateDisplayRenderingModesEXT", &_fn);
-		s_ps.pfn_enumerate_modes = (PFN_xrEnumerateDisplayRenderingModesEXT)_fn;
+		s_ps.gipa(s_ps.instance, "xrEnumerateDisplayRenderingModesDXR", &_fn);
+		s_ps.pfn_enumerate_modes = (PFN_xrEnumerateDisplayRenderingModesDXR)_fn;
 		_fn = NULL;
-		s_ps.gipa(s_ps.instance, "xrRequestDisplayRenderingModeEXT", &_fn);
-		s_ps.pfn_request_rendering_mode = (PFN_xrRequestDisplayRenderingModeEXT)_fn;
+		s_ps.gipa(s_ps.instance, "xrRequestDisplayRenderingModeDXR", &_fn);
+		s_ps.pfn_request_rendering_mode = (PFN_xrRequestDisplayRenderingModeDXR)_fn;
 		_fn = NULL;
-		s_ps.gipa(s_ps.instance, "xrRequestDisplayModeEXT", &_fn);
-		s_ps.pfn_request_display_mode = (PFN_xrRequestDisplayModeEXT)_fn;
+		s_ps.gipa(s_ps.instance, "xrRequestDisplayModeDXR", &_fn);
+		s_ps.pfn_request_display_mode = (PFN_xrRequestDisplayModeDXR)_fn;
 		_fn = NULL;
-		s_ps.gipa(s_ps.instance, "xrRequestEyeTrackingModeEXT", &_fn);
-		s_ps.pfn_request_eye_tracking_mode = (PFN_xrRequestEyeTrackingModeEXT)_fn;
+		s_ps.gipa(s_ps.instance, "xrRequestEyeTrackingModeDXR", &_fn);
+		s_ps.pfn_request_eye_tracking_mode = (PFN_xrRequestEyeTrackingModeDXR)_fn;
 		// Zones (#166 Phase B) — soft-resolve; inert on older runtimes.
 		_fn = NULL;
-		s_ps.gipa(s_ps.instance, "xrGetDisplayZoneCapabilitiesEXT", &_fn);
-		s_ps.pfn_get_zone_caps = (PFN_xrGetDisplayZoneCapabilitiesEXT)_fn;
+		s_ps.gipa(s_ps.instance, "xrGetDisplayZoneCapabilitiesDXR", &_fn);
+		s_ps.pfn_get_zone_caps = (PFN_xrGetDisplayZoneCapabilitiesDXR)_fn;
 		_fn = NULL;
-		s_ps.gipa(s_ps.instance, "xrGetDisplayZoneRecommendedViewSizeEXT", &_fn);
-		s_ps.pfn_get_zone_view_size = (PFN_xrGetDisplayZoneRecommendedViewSizeEXT)_fn;
+		s_ps.gipa(s_ps.instance, "xrGetDisplayZoneRecommendedViewSizeDXR", &_fn);
+		s_ps.pfn_get_zone_view_size = (PFN_xrGetDisplayZoneRecommendedViewSizeDXR)_fn;
 		// Atlas capture (#140) — soft-resolve; inert if the runtime lacks it.
 		_fn = NULL;
-		s_ps.gipa(s_ps.instance, "xrCaptureAtlasEXT", &_fn);
-		s_ps.pfn_capture_atlas = (PFN_xrCaptureAtlasEXT)_fn;
+		s_ps.gipa(s_ps.instance, "xrCaptureAtlasDXR", &_fn);
+		s_ps.pfn_capture_atlas = (PFN_xrCaptureAtlasDXR)_fn;
 	}
 	return 1;
 }
@@ -757,7 +757,7 @@ static void ps_enumerate_modes(void)
 		return;
 	if (total > PS_MAX_RENDERING_MODES) total = PS_MAX_RENDERING_MODES;
 	for (uint32_t i = 0; i < total; i++)
-		s_ps.modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_EXT;
+		s_ps.modes[i].type = XR_TYPE_DISPLAY_RENDERING_MODE_INFO_DXR;
 	if (XR_SUCCEEDED(s_ps.pfn_enumerate_modes(s_ps.session, total, &total, s_ps.modes)))
 		s_ps.mode_count = total;
 	for (uint32_t i = 0; i < s_ps.mode_count; i++) {
@@ -797,7 +797,7 @@ static void ps_enumerate_modes(void)
 }
 
 // Find an enumerated mode by modeIndex (NULL if absent).
-static const XrDisplayRenderingModeInfoEXT *ps_find_mode(uint32_t mode_index)
+static const XrDisplayRenderingModeInfoDXR *ps_find_mode(uint32_t mode_index)
 {
 	for (uint32_t i = 0; i < s_ps.mode_count; i++)
 		if (s_ps.modes[i].modeIndex == mode_index) return &s_ps.modes[i];
@@ -809,7 +809,7 @@ static const XrDisplayRenderingModeInfoEXT *ps_find_mode(uint32_t mode_index)
 // startup comes up in 3D. (#172 P4)
 static uint32_t ps_active_view_count(void)
 {
-	const XrDisplayRenderingModeInfoEXT *m = ps_find_mode(s_ps.active_mode_index);
+	const XrDisplayRenderingModeInfoDXR *m = ps_find_mode(s_ps.active_mode_index);
 	if (m && m->viewCount >= 1) return m->viewCount >= 2 ? 2 : 1;
 	return 2;
 }
@@ -822,7 +822,7 @@ static uint32_t ps_active_view_count(void)
 // half-res instead of full-res (#172 P4).
 static void ps_active_view_scale(float *sx, float *sy)
 {
-	const XrDisplayRenderingModeInfoEXT *m = ps_find_mode(s_ps.active_mode_index);
+	const XrDisplayRenderingModeInfoDXR *m = ps_find_mode(s_ps.active_mode_index);
 	if (!m) {
 		for (uint32_t i = 0; i < s_ps.mode_count; i++)
 			if (s_ps.modes[i].hardwareDisplay3D && s_ps.modes[i].viewCount == 2)
@@ -866,7 +866,7 @@ static void ps_window_size(uint32_t *w, uint32_t *h)
 }
 
 // ============================================================================
-// Zones (XR_EXT_display_zones) — #166 Phase B
+// Zones (XR_DXR_display_zones) — #166 Phase B
 // ============================================================================
 
 // Lazy caps query: zones are usable iff the runtime advertised the extension,
@@ -878,7 +878,7 @@ static int ps_zones_ready(void)
 		return 0;
 	if (s_ps.zone_caps_ok < 0) {
 		if (s_ps.session == XR_NULL_HANDLE) return 0;
-		XrDisplayZoneCapabilitiesEXT caps = {XR_TYPE_DISPLAY_ZONE_CAPABILITIES_EXT};
+		XrDisplayZoneCapabilitiesDXR caps = {XR_TYPE_DISPLAY_ZONE_CAPABILITIES_DXR};
 		XrResult cr = s_ps.pfn_get_zone_caps(s_ps.session, &caps);
 		s_ps.zone_caps_ok = (XR_SUCCEEDED(cr) && caps.supported && caps.maxZones3D >= 1) ? 1 : 0;
 		s_ps.zone_max_3d = caps.maxZones3D;
@@ -1880,7 +1880,7 @@ void dxr_prov_get_wsui_bridge(uint32_t w, uint32_t h,
 // out_layer. Returns 1 if the layer should be submitted, else 0. Called from
 // dxr_prov_submit_frame AFTER the projection bridge copy (own_cmd_list is free and
 // the shared-fence wait already ordered the own queue after Unity's writes).
-static int ps_submit_wsui(XrCompositionLayerWindowSpaceEXT *out_layer)
+static int ps_submit_wsui(XrCompositionLayerWindowSpaceDXR *out_layer)
 {
 	if (!out_layer) return 0;
 	memset(out_layer, 0, sizeof(*out_layer));
@@ -1914,7 +1914,7 @@ static int ps_submit_wsui(XrCompositionLayerWindowSpaceEXT *out_layer)
 	XrSwapchainImageReleaseInfo ri = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
 	s_ps.pfn_release_swapchain_image(s_ps.wsui_swapchain, &ri);
 
-	out_layer->type = XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT;
+	out_layer->type = XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_DXR;
 	out_layer->next = NULL;
 	out_layer->layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
 	out_layer->subImage.swapchain = s_ps.wsui_swapchain;
@@ -1981,7 +1981,7 @@ static int ps_submit_wsui(XrCompositionLayerWindowSpaceEXT *out_layer)
 	XrSwapchainImageReleaseInfo ri = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
 	s_ps.pfn_release_swapchain_image(s_ps.wsui_swapchain, &ri);
 
-	out_layer->type = XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_EXT;
+	out_layer->type = XR_TYPE_COMPOSITION_LAYER_WINDOW_SPACE_DXR;
 	out_layer->next = NULL;
 	out_layer->layerFlags = XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
 	out_layer->subImage.swapchain = s_ps.wsui_swapchain;
@@ -2006,7 +2006,7 @@ static int ps_create_local2d(uint32_t w, uint32_t h)
 	// Metal (#206): an arraySize=1 overlay swapchain on Unity's device. No bridge —
 	// submit blits the C#-registered Unity id<MTLTexture> straight in (same device).
 	// Twin of the wsui Metal arm (ps_create_wsui); the only difference downstream is
-	// a pixel rect at submit (XrCompositionLayerLocal2DEXT) rather than fractional.
+	// a pixel rect at submit (XrCompositionLayerLocal2DDXR) rather than fractional.
 	if (w == 0 || h == 0) return 0;
 	if (s_ps.graphics_api != DXR_GFX_METAL || !s_ps.metal_queue) return 0;
 	if (s_ps.l2d_swapchain_created && s_ps.l2d_registered_w == w && s_ps.l2d_registered_h == h)
@@ -2174,9 +2174,9 @@ void dxr_prov_set_local2d_rect(int32_t x, int32_t y, int32_t w, int32_t h)
 }
 
 // Per-frame: copy the Local2D bridge into its overlay swapchain image and fill the
-// layer (XrCompositionLayerLocal2DEXT, dest = client-window pixel rect). Returns 1
+// layer (XrCompositionLayerLocal2DDXR, dest = client-window pixel rect). Returns 1
 // if the layer should be submitted. Called from submit after the projection copy.
-static int ps_submit_local2d(XrCompositionLayerLocal2DEXT *out_layer)
+static int ps_submit_local2d(XrCompositionLayerLocal2DDXR *out_layer)
 {
 	if (!out_layer) return 0;
 	memset(out_layer, 0, sizeof(*out_layer));
@@ -2211,7 +2211,7 @@ static int ps_submit_local2d(XrCompositionLayerLocal2DEXT *out_layer)
 	XrSwapchainImageReleaseInfo ri_mtl = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
 	s_ps.pfn_release_swapchain_image(s_ps.l2d_swapchain, &ri_mtl);
 
-	out_layer->type = XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT;
+	out_layer->type = XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_DXR;
 	out_layer->next = NULL;
 	// Unity Canvas is straight (unpremultiplied) alpha — flag it so the runtime
 	// doesn't double-darken (matches the D3D arm below).
@@ -2273,7 +2273,7 @@ static int ps_submit_local2d(XrCompositionLayerLocal2DEXT *out_layer)
 	XrSwapchainImageReleaseInfo ri = {XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO};
 	s_ps.pfn_release_swapchain_image(s_ps.l2d_swapchain, &ri);
 
-	out_layer->type = XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_EXT;
+	out_layer->type = XR_TYPE_COMPOSITION_LAYER_LOCAL_2D_DXR;
 	out_layer->next = NULL;
 	// Unity Canvas is straight (unpremultiplied) alpha — flag it so the runtime
 	// doesn't double-darken (matches the hook path's Local2D + avatar bubble).
@@ -2501,7 +2501,7 @@ int dxr_prov_consume_zone_rewrap(uint32_t index)
 	return 1;
 }
 
-// Locate each extra zone (zone-scoped, XrDisplayZoneEXT chained) → z->views, and
+// Locate each extra zone (zone-scoped, XrDisplayZoneDXR chained) → z->views, and
 // acquire its swapchain image. Mirrors the primary locate in dxr_prov_begin_frame.
 static void ps_locate_extra_zones(XrTime display_time)
 {
@@ -2517,9 +2517,9 @@ static void ps_locate_extra_zones(XrTime display_time)
 		li.displayTime = display_time; li.space = s_ps.local_space;
 		XrView views[PS_MAX_VIEWS]; for (int k = 0; k < PS_MAX_VIEWS; k++) views[k] = {XR_TYPE_VIEW};
 		XrViewState vstate = {XR_TYPE_VIEW_STATE};
-		XrDisplayRigEXT display_rig = {XR_TYPE_DISPLAY_RIG_EXT};
-		XrCameraRigEXT  camera_rig  = {XR_TYPE_CAMERA_RIG_EXT};
-		XrDisplayZoneEXT zone = {XR_TYPE_DISPLAY_ZONE_EXT};
+		XrDisplayRigDXR display_rig = {XR_TYPE_DISPLAY_RIG_DXR};
+		XrCameraRigDXR  camera_rig  = {XR_TYPE_CAMERA_RIG_DXR};
+		XrDisplayZoneDXR zone = {XR_TYPE_DISPLAY_ZONE_DXR};
 		XrPosef rig_pose = s_ps.display_pose_set ? s_ps.display_pose : XrPosef{{0, 0, 0, 1}, {0, 0, 0}};
 		if (s_ps.has_view_rig) {
 			if (s_ps.camera_centric) {
@@ -2865,7 +2865,7 @@ int dxr_prov_session_start(const char *runtime_json_path,
 	}
 	s_ps.gipa = rr.getInstanceProcAddr;
 
-	// --- Probe XR_EXT_view_rig before requesting it (older runtimes reject unknown) ---
+	// --- Probe XR_DXR_view_rig before requesting it (older runtimes reject unknown) ---
 	{
 		PFN_xrVoidFunction fn = NULL;
 		s_ps.gipa(XR_NULL_HANDLE, "xrEnumerateInstanceExtensionProperties", &fn);
@@ -2878,13 +2878,13 @@ int dxr_prov_session_start(const char *runtime_json_path,
 				for (uint32_t i = 0; i < avail; i++) props[i].type = XR_TYPE_EXTENSION_PROPERTIES;
 				if (XR_SUCCEEDED(enum_ext(NULL, avail, &avail, props))) {
 					for (uint32_t i = 0; i < avail; i++) {
-						if (strcmp(props[i].extensionName, XR_EXT_VIEW_RIG_EXTENSION_NAME) == 0)
+						if (strcmp(props[i].extensionName, XR_DXR_VIEW_RIG_EXTENSION_NAME) == 0)
 							s_ps.has_view_rig = 1;
-						else if (strcmp(props[i].extensionName, XR_EXT_DISPLAY_ZONES_EXTENSION_NAME) == 0)
+						else if (strcmp(props[i].extensionName, XR_DXR_DISPLAY_ZONES_EXTENSION_NAME) == 0)
 							s_ps.has_display_zones = 1;
-						else if (strcmp(props[i].extensionName, XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME) == 0)
+						else if (strcmp(props[i].extensionName, XR_DXR_LOCAL_3D_ZONE_EXTENSION_NAME) == 0)
 							s_ps.has_local_3d_zone = 1;
-						else if (strcmp(props[i].extensionName, XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME) == 0)
+						else if (strcmp(props[i].extensionName, XR_DXR_ATLAS_CAPTURE_EXTENSION_NAME) == 0)
 							s_ps.has_atlas_capture = 1;
 					}
 				}
@@ -2894,34 +2894,34 @@ int dxr_prov_session_start(const char *runtime_json_path,
 		ps_log("[DisplayXR-PROV] display_zones: %s; local_3d_zone: %s\n",
 		       s_ps.has_display_zones ? "AVAILABLE" : "no",
 		       s_ps.has_local_3d_zone ? "AVAILABLE" : "no");
-		ps_log("[DisplayXR-PROV] XR_EXT_view_rig: %s\n",
+		ps_log("[DisplayXR-PROV] XR_DXR_view_rig: %s\n",
 		       s_ps.has_view_rig ? "AVAILABLE" : "not found (no stereo)");
-		ps_log("[DisplayXR-PROV] XR_EXT_atlas_capture: %s\n",
+		ps_log("[DisplayXR-PROV] XR_DXR_atlas_capture: %s\n",
 		       s_ps.has_atlas_capture ? "AVAILABLE" : "no (screenshot inert)");
 	}
 
 	// --- Create instance ---
 	const char *extensions[8];
 	uint32_t ext_count = 0;
-	extensions[ext_count++] = XR_EXT_DISPLAY_INFO_EXTENSION_NAME;
+	extensions[ext_count++] = XR_DXR_DISPLAY_INFO_EXTENSION_NAME;
 #ifdef _WIN32
 	extensions[ext_count++] = is_d3d11 ? "XR_KHR_D3D11_enable" : "XR_KHR_D3D12_enable";
-	extensions[ext_count++] = XR_EXT_WIN32_WINDOW_BINDING_EXTENSION_NAME;
+	extensions[ext_count++] = XR_DXR_WIN32_WINDOW_BINDING_EXTENSION_NAME;
 #else
 	extensions[ext_count++] = XR_KHR_METAL_ENABLE_EXTENSION_NAME;
-	extensions[ext_count++] = XR_EXT_COCOA_WINDOW_BINDING_EXTENSION_NAME;
+	extensions[ext_count++] = XR_DXR_COCOA_WINDOW_BINDING_EXTENSION_NAME;
 #endif
-	if (s_ps.has_view_rig) extensions[ext_count++] = XR_EXT_VIEW_RIG_EXTENSION_NAME;
+	if (s_ps.has_view_rig) extensions[ext_count++] = XR_DXR_VIEW_RIG_EXTENSION_NAME;
 	// Zones (#166 Phase B): display_zones needs view_rig (composes on top of it);
 	// local_3d_zone is required to submit Local2D layers for the 2D bands.
 	if (s_ps.has_display_zones && s_ps.has_view_rig)
-		extensions[ext_count++] = XR_EXT_DISPLAY_ZONES_EXTENSION_NAME;
+		extensions[ext_count++] = XR_DXR_DISPLAY_ZONES_EXTENSION_NAME;
 	if (s_ps.has_local_3d_zone)
-		extensions[ext_count++] = XR_EXT_LOCAL_3D_ZONE_EXTENSION_NAME;
+		extensions[ext_count++] = XR_DXR_LOCAL_3D_ZONE_EXTENSION_NAME;
 	// Atlas capture (#140): app-facing screenshot ('I' key). Enable
 	// unconditionally-if-advertised — independent of transparency/zones.
 	if (s_ps.has_atlas_capture)
-		extensions[ext_count++] = XR_EXT_ATLAS_CAPTURE_EXTENSION_NAME;
+		extensions[ext_count++] = XR_DXR_ATLAS_CAPTURE_EXTENSION_NAME;
 
 	PFN_xrVoidFunction fn_create = NULL;
 	s_ps.gipa(XR_NULL_HANDLE, "xrCreateInstance", &fn_create);
@@ -2989,8 +2989,8 @@ int dxr_prov_session_start(const char *runtime_json_path,
 #endif
 
 	// --- Display info ---
-	XrDisplayInfoEXT di = {};
-	di.type = XR_TYPE_DISPLAY_INFO_EXT;
+	XrDisplayInfoDXR di = {};
+	di.type = XR_TYPE_DISPLAY_INFO_DXR;
 	XrSystemProperties sp = {XR_TYPE_SYSTEM_PROPERTIES};
 	sp.next = &di;
 	if (XR_SUCCEEDED(s_ps.pfn_get_system_properties(s_ps.instance, s_ps.system_id, &sp))) {
@@ -3056,8 +3056,8 @@ int dxr_prov_session_start(const char *runtime_json_path,
 
 #ifdef _WIN32
 	// --- Session: graphics binding on UNITY'S device + window binding (overlay HWND) ---
-	XrWin32WindowBindingCreateInfoEXT win_binding = {};
-	win_binding.type = XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_EXT;
+	XrWin32WindowBindingCreateInfoDXR win_binding = {};
+	win_binding.type = XR_TYPE_WIN32_WINDOW_BINDING_CREATE_INFO_DXR;
 	win_binding.windowHandle = s_ps.overlay_hwnd;
 	win_binding.readbackCallback = NULL;
 	win_binding.readbackUserdata = NULL;
@@ -3092,8 +3092,8 @@ int dxr_prov_session_start(const char *runtime_json_path,
 	// viewHandle == NULL → the runtime self-hosts its NSWindow + CAMetalLayer (the
 	// SELFHOST shape); Phase 2 (#204) switches to displayxr_get_app_main_view()'s
 	// NSView for in-app weave once frames are correct.
-	XrCocoaWindowBindingCreateInfoEXT cocoa_binding = {};
-	cocoa_binding.type = XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_EXT;
+	XrCocoaWindowBindingCreateInfoDXR cocoa_binding = {};
+	cocoa_binding.type = XR_TYPE_COCOA_WINDOW_BINDING_CREATE_INFO_DXR;
 	cocoa_binding.viewHandle = s_ps.overlay_hwnd;
 	cocoa_binding.readbackCallback = NULL;
 	cocoa_binding.readbackUserdata = NULL;
@@ -3276,7 +3276,7 @@ int dxr_prov_wants_transparent(void) { return s_ps.transparent_requested; }
 
 // --- Zones (#166 Phase B) ---------------------------------------------------
 // Define the single 3D-zone rect (client-window px, top-left origin). The locate
-// chains XrDisplayZoneEXT in front of the rig and submit chains it on the
+// chains XrDisplayZoneDXR in front of the rig and submit chains it on the
 // projection layer; the swapchain is (re)sized to the zone's recommended view
 // size. w<=0||h<=0 clears (full-window framing). Seed BEFORE the session starts
 // (demo SubsystemRegistration) so the swapchain is born zone-sized — a later
@@ -3457,8 +3457,8 @@ void dxr_prov_poll_events(void)
 				break;
 			default: break;
 			}
-		} else if (ev.type == XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_EXT) {
-			XrEventDataRenderingModeChangedEXT *mc = (XrEventDataRenderingModeChangedEXT *)&ev;
+		} else if (ev.type == XR_TYPE_EVENT_DATA_RENDERING_MODE_CHANGED_DXR) {
+			XrEventDataRenderingModeChangedDXR *mc = (XrEventDataRenderingModeChangedDXR *)&ev;
 			// Re-enumerate so active_mode_index + per-mode tiling/scale refresh;
 			// the per-frame render rect (dxr_prov_get_render_rect) then adapts with
 			// NO swapchain realloc (worst-case sized). Latch for C#.
@@ -3469,8 +3469,8 @@ void dxr_prov_poll_events(void)
 			s_ps.ev_mode_changed = 1;
 			ps_log("[DisplayXR-PROV] event: rendering mode %u -> %u\n",
 			       mc->previousModeIndex, mc->currentModeIndex);
-		} else if (ev.type == XR_TYPE_EVENT_DATA_HARDWARE_DISPLAY_STATE_CHANGED_EXT) {
-			XrEventDataHardwareDisplayStateChangedEXT *hc = (XrEventDataHardwareDisplayStateChangedEXT *)&ev;
+		} else if (ev.type == XR_TYPE_EVENT_DATA_HARDWARE_DISPLAY_STATE_CHANGED_DXR) {
+			XrEventDataHardwareDisplayStateChangedDXR *hc = (XrEventDataHardwareDisplayStateChangedDXR *)&ev;
 			s_ps.ev_hw3d = hc->hardwareDisplay3D ? 1 : 0;
 			s_ps.ev_hw_changed = 1;
 			ps_log("[DisplayXR-PROV] event: hardware 3D -> %d\n", s_ps.ev_hw3d);
@@ -3483,7 +3483,7 @@ void dxr_prov_poll_events(void)
 			// the runtime sends RENDERING_MODE_CHANGED and the provider flips submit count
 			// (and reallocs the tile to full-res 2D).
 			if (s_ps.pfn_request_rendering_mode) {
-				const XrDisplayRenderingModeInfoEXT *cur = ps_find_mode(s_ps.active_mode_index);
+				const XrDisplayRenderingModeInfoDXR *cur = ps_find_mode(s_ps.active_mode_index);
 				int cur_is3d = cur ? (cur->hardwareDisplay3D ? 1 : 0) : 1;
 				if (cur_is3d != s_ps.ev_hw3d) {
 					for (uint32_t i = 0; i < s_ps.mode_count; i++) {
@@ -3498,8 +3498,8 @@ void dxr_prov_poll_events(void)
 					}
 				}
 			}
-		} else if (ev.type == XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_EXT) {
-			XrEventDataEyeTrackingStateChangedEXT *tc = (XrEventDataEyeTrackingStateChangedEXT *)&ev;
+		} else if (ev.type == XR_TYPE_EVENT_DATA_EYE_TRACKING_STATE_CHANGED_DXR) {
+			XrEventDataEyeTrackingStateChangedDXR *tc = (XrEventDataEyeTrackingStateChangedDXR *)&ev;
 			s_ps.ev_track_is_tracking = tc->isTracking ? 1 : 0;
 			s_ps.ev_track_mode = (int)tc->activeMode;
 			s_ps.ev_track_changed = 1;
@@ -3550,7 +3550,7 @@ int dxr_prov_begin_frame(uint32_t *out_image_index, int *out_should_render)
 		s_ps.render_h = rh;
 	}
 
-	// --- Locate views (XR_EXT_view_rig chained → render-ready pose+fov) ---
+	// --- Locate views (XR_DXR_view_rig chained → render-ready pose+fov) ---
 	s_ps.view_count = 0;
 	if (s_ps.local_space != XR_NULL_HANDLE && s_ps.pfn_locate_views) {
 		XrViewLocateInfo li = {XR_TYPE_VIEW_LOCATE_INFO};
@@ -3563,14 +3563,14 @@ int dxr_prov_begin_frame(uint32_t *out_image_index, int *out_should_render)
 		XrViewState vstate = {XR_TYPE_VIEW_STATE};
 		uint32_t vcount = 0;
 
-		// XR_EXT_view_rig: chain the rig descriptor matching the active rig mode
-		// (mirrors displayxr_standalone.cpp). Camera-centric → XrCameraRigEXT;
-		// display-centric → XrDisplayRigEXT. The runtime returns render-ready
+		// XR_DXR_view_rig: chain the rig descriptor matching the active rig mode
+		// (mirrors displayxr_standalone.cpp). Camera-centric → XrCameraRigDXR;
+		// display-centric → XrDisplayRigDXR. The runtime returns render-ready
 		// XrView{pose,fov}; the raw channel recovers the raw display-space eyes.
-		XrDisplayRigEXT display_rig = {XR_TYPE_DISPLAY_RIG_EXT};
-		XrCameraRigEXT  camera_rig  = {XR_TYPE_CAMERA_RIG_EXT};
-		XrDisplayZoneEXT locate_zone = {XR_TYPE_DISPLAY_ZONE_EXT};
-		XrViewDisplayRawEXT raw = {XR_TYPE_VIEW_DISPLAY_RAW_EXT};
+		XrDisplayRigDXR display_rig = {XR_TYPE_DISPLAY_RIG_DXR};
+		XrCameraRigDXR  camera_rig  = {XR_TYPE_CAMERA_RIG_DXR};
+		XrDisplayZoneDXR locate_zone = {XR_TYPE_DISPLAY_ZONE_DXR};
+		XrViewDisplayRawDXR raw = {XR_TYPE_VIEW_DISPLAY_RAW_DXR};
 		XrPosef rig_pose = s_ps.display_pose_set ? s_ps.display_pose
 		                                         : XrPosef{{0, 0, 0, 1}, {0, 0, 0}};
 		if (s_ps.has_view_rig) {
@@ -3601,7 +3601,7 @@ int dxr_prov_begin_frame(uint32_t *out_image_index, int *out_should_render)
 				display_rig.perspectiveFactor = s_ps.tunables_set ? s_ps.perspective_factor : 1.0f;
 				li.next = &display_rig;
 			}
-			// Zones (#166 Phase B): chain XrDisplayZoneEXT in FRONT of the rig so the
+			// Zones (#166 Phase B): chain XrDisplayZoneDXR in FRONT of the rig so the
 			// runtime frames the Kooima into the zone rect (the rect IS the canvas).
 			// Same instance is chained on the projection layer at submit.
 			if (ps_zone_active()) {
@@ -3638,7 +3638,7 @@ int dxr_prov_begin_frame(uint32_t *out_image_index, int *out_should_render)
 			// Publish the RAW (pre-Kooima) display-space eyes to shared state so
 			// the editor Scene-view gizmo (DisplayXRGizmoHelpers.TryGetLiveRawEyes)
 			// tracks the head (#189). The gizmo re-applies Kooima itself, so it
-			// wants the raw eyes from the XR_EXT_view_rig raw channel (chained on
+			// wants the raw eyes from the XR_DXR_view_rig raw channel (chained on
 			// vstate.next above), NOT the render-ready views[i].pose — matching the
 			// legacy SA contract (displayxr_standalone.cpp:1603-1618). Only valid
 			// when the rig is chained; otherwise `raw` is a zero-init struct and
@@ -3646,7 +3646,7 @@ int dxr_prov_begin_frame(uint32_t *out_image_index, int *out_should_render)
 			if (s_ps.has_view_rig) {
 				uint32_t raw_n = raw.eyeCountOutput;
 				if (raw_n == 0) raw_n = n; // tolerate a runtime that skipped the raw fill
-				if (raw_n > XR_VIEW_RIG_MAX_RAW_EYES_EXT) raw_n = XR_VIEW_RIG_MAX_RAW_EYES_EXT;
+				if (raw_n > XR_VIEW_RIG_MAX_RAW_EYES_DXR) raw_n = XR_VIEW_RIG_MAX_RAW_EYES_DXR;
 				XrVector3f left  = raw.rawEyes[0];
 				XrVector3f right = raw.rawEyes[raw_n >= 2 ? 1 : 0];
 				displayxr_state_set_eye_positions(&left, &right, raw.isTracking ? 1 : 0);
@@ -4088,7 +4088,7 @@ int dxr_prov_submit_frame(uint32_t image_index)
 
 	// Zones (#166 Phase B): bind the projection layer's views into the zone rect.
 	// SAME instance/values as the locate chain; the submit values are authoritative.
-	XrDisplayZoneEXT submit_zone = {XR_TYPE_DISPLAY_ZONE_EXT};
+	XrDisplayZoneDXR submit_zone = {XR_TYPE_DISPLAY_ZONE_DXR};
 	int zone_frame = ps_zone_active();
 	if (zone_frame) {
 		submit_zone.zoneId = s_ps.zone_id ? s_ps.zone_id : 1;
@@ -4116,7 +4116,7 @@ int dxr_prov_submit_frame(uint32_t image_index)
 	// zone-chained projection layer. Structs persist until xrEndFrame below.
 	XrCompositionLayerProjectionView extra_pv[PS_MAX_ZONES - 1][2] = {};
 	XrCompositionLayerProjection     extra_layer[PS_MAX_ZONES - 1] = {};
-	XrDisplayZoneEXT                 extra_zone_struct[PS_MAX_ZONES - 1] = {};
+	XrDisplayZoneDXR                 extra_zone_struct[PS_MAX_ZONES - 1] = {};
 	int extra_has[PS_MAX_ZONES - 1] = {};
 	for (uint32_t i = 0; i < s_ps.extra_zone_count; i++) {
 		ProviderExtraZone *z = &s_ps.extra_zones[i];
@@ -4135,7 +4135,7 @@ int dxr_prov_submit_frame(uint32_t image_index)
 			extra_pv[i][eye].subImage.imageRect.extent = {(int32_t)z->sc_width, (int32_t)z->sc_height};
 			extra_pv[i][eye].subImage.imageArrayIndex = eye;
 		}
-		extra_zone_struct[i].type = XR_TYPE_DISPLAY_ZONE_EXT;
+		extra_zone_struct[i].type = XR_TYPE_DISPLAY_ZONE_DXR;
 		extra_zone_struct[i].zoneId = z->zone_id;
 		extra_zone_struct[i].rect.offset = {z->rect_x, z->rect_y};
 		extra_zone_struct[i].rect.extent = {z->rect_w, z->rect_h};
@@ -4152,11 +4152,11 @@ int dxr_prov_submit_frame(uint32_t image_index)
 	// Local2D band(s): post-weave 2D content at a client-window pixel rect,
 	// composited over the woven 3D (the "glass over 3D" 2D zone). Inactive when no
 	// rect/bridge is registered.
-	XrCompositionLayerLocal2DEXT l2d_layer = {};
+	XrCompositionLayerLocal2DDXR l2d_layer = {};
 	int has_l2d = ps_submit_local2d(&l2d_layer);
 
 	// Window-space UI (HUD). Composites over everything (fractional coords + disparity).
-	XrCompositionLayerWindowSpaceEXT wsui_layer = {};
+	XrCompositionLayerWindowSpaceDXR wsui_layer = {};
 	int has_wsui = ps_submit_wsui(&wsui_layer);
 
 	// Order: 3D projections (primary + extra zones) under, Local2D bands over the 3D,
@@ -4283,7 +4283,7 @@ void dxr_prov_get_render_rect(uint32_t *out_w, uint32_t *out_h)
 }
 
 // ============================================================================
-// Rendering modes (XR_EXT_display_info)
+// Rendering modes (XR_DXR_display_info)
 // ============================================================================
 
 uint32_t dxr_prov_get_mode_count(void) { return s_ps.mode_count; }
@@ -4291,7 +4291,7 @@ uint32_t dxr_prov_get_mode_count(void) { return s_ps.mode_count; }
 int dxr_prov_get_mode_info(uint32_t index, DxrProvModeInfo *out_info)
 {
 	if (!out_info || index >= s_ps.mode_count) return 0;
-	const XrDisplayRenderingModeInfoEXT *m = &s_ps.modes[index];
+	const XrDisplayRenderingModeInfoDXR *m = &s_ps.modes[index];
 	out_info->mode_index = m->modeIndex;
 	out_info->view_count = m->viewCount;
 	out_info->tile_columns = m->tileColumns;
@@ -4322,7 +4322,7 @@ int dxr_prov_request_display_mode(int mode3d)
 {
 	if (!s_ps.session || !s_ps.pfn_request_display_mode) return 0;
 	XrResult r = s_ps.pfn_request_display_mode(s_ps.session,
-	        mode3d ? XR_DISPLAY_MODE_3D_EXT : XR_DISPLAY_MODE_2D_EXT);
+	        mode3d ? XR_DISPLAY_MODE_3D_DXR : XR_DISPLAY_MODE_2D_DXR);
 	ps_log("[DisplayXR-PROV] request display mode %s -> %d\n", mode3d ? "3D" : "2D", r);
 	return XR_SUCCEEDED(r) ? 1 : 0;
 }
@@ -4331,12 +4331,12 @@ int dxr_prov_set_eye_tracking_mode(int manual)
 {
 	if (!s_ps.session || !s_ps.pfn_request_eye_tracking_mode) return 0;
 	XrResult r = s_ps.pfn_request_eye_tracking_mode(s_ps.session,
-	        manual ? XR_EYE_TRACKING_MODE_MANUAL_EXT : XR_EYE_TRACKING_MODE_MANAGED_EXT);
+	        manual ? XR_EYE_TRACKING_MODE_MANUAL_DXR : XR_EYE_TRACKING_MODE_MANAGED_DXR);
 	ps_log("[DisplayXR-PROV] request eye-tracking mode %s -> %d\n", manual ? "MANUAL" : "MANAGED", r);
 	return XR_SUCCEEDED(r) ? 1 : 0;
 }
 
-// ---- Atlas capture (XR_EXT_atlas_capture, #140) -----------------------------
+// ---- Atlas capture (XR_DXR_atlas_capture, #140) -----------------------------
 
 // Atlas capture: hand the runtime a path prefix + stage; it reads back its own
 // compositor atlas and writes the PNG on the next composed frame. Non-blocking —
@@ -4349,14 +4349,14 @@ int dxr_prov_capture_atlas(const char *path_prefix, int stage)
 		return 0; // Extension not resolved or no live session
 	}
 
-	XrAtlasCaptureInfoEXT info = {};
-	info.type = XR_TYPE_ATLAS_CAPTURE_INFO_EXT;
+	XrAtlasCaptureInfoDXR info = {};
+	info.type = XR_TYPE_ATLAS_CAPTURE_INFO_DXR;
 	info.next = NULL;
-	info.stage = (stage != 0) ? XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_EXT
-	                          : XR_ATLAS_CAPTURE_STAGE_POST_COMPOSE_EXT;
+	info.stage = (stage != 0) ? XR_ATLAS_CAPTURE_STAGE_PROJECTION_ONLY_DXR
+	                          : XR_ATLAS_CAPTURE_STAGE_POST_COMPOSE_DXR;
 	if (path_prefix != NULL) {
-		strncpy(info.pathPrefix, path_prefix, XR_ATLAS_CAPTURE_PATH_MAX_EXT - 1);
-		info.pathPrefix[XR_ATLAS_CAPTURE_PATH_MAX_EXT - 1] = '\0';
+		strncpy(info.pathPrefix, path_prefix, XR_ATLAS_CAPTURE_PATH_MAX_DXR - 1);
+		info.pathPrefix[XR_ATLAS_CAPTURE_PATH_MAX_DXR - 1] = '\0';
 	}
 
 	XrResult result = s_ps.pfn_capture_atlas(s_ps.session, &info, NULL);

--- a/native~/displayxr_xrprovider/displayxr_provider_session.h
+++ b/native~/displayxr_xrprovider/displayxr_provider_session.h
@@ -7,7 +7,7 @@
 // This is the provider's analog of displayxr_standalone.cpp: it loads the
 // DisplayXR runtime directly via xrNegotiateLoaderRuntimeInterface, creates the
 // instance/system/session, enables the EXT extensions, enumerates rendering
-// modes, creates the (SPI, arraySize=2) swapchain, and consumes XR_EXT_view_rig
+// modes, creates the (SPI, arraySize=2) swapchain, and consumes XR_DXR_view_rig
 // render-ready views — but it differs from the standalone in two ways:
 //
 //   1. The graphics binding is created on UNITY'S OWN D3D12 device + queue
@@ -67,7 +67,7 @@ typedef enum DxrGfxKind {
 	DXR_GFX_METAL,  // macOS (#202/#204)
 } DxrGfxKind;
 
-/// One render-ready view consumed from xrLocateViews (XR_EXT_view_rig).
+/// One render-ready view consumed from xrLocateViews (XR_DXR_view_rig).
 typedef struct DxrProvView {
 	float position[3];    ///< Eye position, OpenXR LOCAL (display) space.
 	float orientation[4]; ///< Eye orientation quaternion (x,y,z,w).
@@ -75,7 +75,7 @@ typedef struct DxrProvView {
 	int   valid;          ///< 1 if this view is render-ready.
 } DxrProvView;
 
-/// Display geometry surfaced from XR_EXT_display_info (for C# / logging).
+/// Display geometry surfaced from XR_DXR_display_info (for C# / logging).
 typedef struct DxrProvDisplayInfo {
 	float    width_m, height_m;          ///< Physical display size (meters).
 	uint32_t pixel_width, pixel_height;  ///< Display pixel dimensions.
@@ -84,7 +84,7 @@ typedef struct DxrProvDisplayInfo {
 	int      is_valid;
 } DxrProvDisplayInfo;
 
-/// One enumerated rendering mode surfaced to C# (XrDisplayRenderingModeInfoEXT).
+/// One enumerated rendering mode surfaced to C# (XrDisplayRenderingModeInfoDXR).
 typedef struct DxrProvModeInfo {
 	uint32_t mode_index;
 	uint32_t view_count;
@@ -205,10 +205,10 @@ DISPLAYXR_EXPORT void dxr_prov_set_transparent_background(int enable);
 int dxr_prov_wants_transparent(void);
 
 /// Set the single 3D-zone rect (client-window px, top-left origin) the runtime
-/// frames the Kooima 3D into (#166 Phase B). The locate chains XrDisplayZoneEXT in
+/// frames the Kooima 3D into (#166 Phase B). The locate chains XrDisplayZoneDXR in
 /// front of the view-rig and submit chains the same zone on the projection layer;
 /// the swapchain is sized to the zone's recommended view size. w<=0||h<=0 clears
-/// (full-window framing). Requires the runtime to advertise XR_EXT_display_zones.
+/// (full-window framing). Requires the runtime to advertise XR_DXR_display_zones.
 /// Seed BEFORE the session starts (like the hook SeedLaunchZone) for born-zone-sized.
 DISPLAYXR_EXPORT void dxr_prov_set_3d_zone_rect(int32_t x, int32_t y, int32_t w, int32_t h);
 
@@ -260,7 +260,7 @@ DISPLAYXR_EXPORT int dxr_prov_get_zone_rect_px(uint32_t zone, int *x, int *y, in
 /// Local2D layer (#166 Phase B): lazily create the provider's Local2D overlay
 /// swapchain + cross-device bridge sized to w×h and return the Unity-device handle
 /// of the bridge. C# (DisplayXRLocal2D) Graphics.CopyTexture's its canvas RT into it
-/// each frame; the provider submits an XrCompositionLayerLocal2DEXT at the pixel
+/// each frame; the provider submits an XrCompositionLayerLocal2DDXR at the pixel
 /// rect. Mirrors dxr_prov_get_wsui_bridge. *out_ptr = NULL when no session running.
 DISPLAYXR_EXPORT void dxr_prov_get_local2d_bridge(uint32_t w, uint32_t h,
                                                   void **out_ptr, uint32_t *out_w, uint32_t *out_h);
@@ -329,9 +329,9 @@ void dxr_prov_end_frame_empty(void);
 /// displayxr_standalone_set_tunables so DisplayXRDisplay (display-centric) and
 /// DisplayXRCamera (camera-centric) both drive the provider:
 ///   - display-centric (camera_centric=0): uses virtual_display_height, ipd,
-///     parallax, perspective → chained as XrDisplayRigEXT.
+///     parallax, perspective → chained as XrDisplayRigDXR.
 ///   - camera-centric  (camera_centric=1): uses inv_convergence_distance,
-///     fov_override (= tan(vFov/2)), ipd, parallax → chained as XrCameraRigEXT.
+///     fov_override (= tan(vFov/2)), ipd, parallax → chained as XrCameraRigDXR.
 /// near_z/far_z are owned by Unity's projection (not the rig descriptor); stored
 /// but unused, matching the standalone. Scale-as-zoom is folded into
 /// virtual_display_height / inv_convergence_distance on the C# side (the rig's
@@ -356,10 +356,10 @@ DISPLAYXR_EXPORT int dxr_prov_get_display_pose_oxr(float out_pos[3], float out_q
 
 // ---- Queries ----------------------------------------------------------------
 
-/// Display info surfaced from XR_EXT_display_info.
+/// Display info surfaced from XR_DXR_display_info.
 DISPLAYXR_EXPORT void dxr_prov_get_display_info(DxrProvDisplayInfo *out_info);
 
-/// Whether the runtime advertised XR_EXT_view_rig (else no stereo — WARN+passthrough).
+/// Whether the runtime advertised XR_DXR_view_rig (else no stereo — WARN+passthrough).
 int  dxr_prov_has_view_rig(void);
 
 /// The active per-view RENDER rect this frame = window(overlay client) ×
@@ -377,7 +377,7 @@ DISPLAYXR_EXPORT void dxr_prov_get_render_rect(uint32_t *out_w, uint32_t *out_h)
 DISPLAYXR_EXPORT void dxr_prov_get_wsui_bridge(uint32_t w, uint32_t h,
                                                void **out_ptr, uint32_t *out_w, uint32_t *out_h);
 
-// ---- Rendering modes (XR_EXT_display_info) ----------------------------------
+// ---- Rendering modes (XR_DXR_display_info) ----------------------------------
 
 /// Number of enumerated rendering modes.
 DISPLAYXR_EXPORT uint32_t dxr_prov_get_mode_count(void);
@@ -388,19 +388,19 @@ DISPLAYXR_EXPORT int  dxr_prov_get_mode_info(uint32_t index, DxrProvModeInfo *ou
 /// modeIndex of the currently active mode (isActive), or 0 if unknown.
 DISPLAYXR_EXPORT uint32_t dxr_prov_get_active_mode_index(void);
 
-/// Request a vendor rendering mode by modeIndex (xrRequestDisplayRenderingModeEXT).
+/// Request a vendor rendering mode by modeIndex (xrRequestDisplayRenderingModeDXR).
 /// Returns 1 on XR_SUCCEEDED.
 DISPLAYXR_EXPORT int  dxr_prov_request_rendering_mode(uint32_t mode_index);
 
-/// Request the hardware 2D/3D display state (xrRequestDisplayModeEXT). mode3d=1
-/// → XR_DISPLAY_MODE_3D_EXT, 0 → 2D. Returns 1 on XR_SUCCEEDED.
+/// Request the hardware 2D/3D display state (xrRequestDisplayModeDXR). mode3d=1
+/// → XR_DISPLAY_MODE_3D_DXR, 0 → 2D. Returns 1 on XR_SUCCEEDED.
 DISPLAYXR_EXPORT int  dxr_prov_request_display_mode(int mode3d);
 
-/// Request the eye-tracking mode (xrRequestEyeTrackingModeEXT). manual=1 →
+/// Request the eye-tracking mode (xrRequestEyeTrackingModeDXR). manual=1 →
 /// MANUAL, 0 → MANAGED. Returns 1 on XR_SUCCEEDED (0 if unsupported/unresolved).
 DISPLAYXR_EXPORT int  dxr_prov_set_eye_tracking_mode(int manual);
 
-// ---- Atlas capture (XR_EXT_atlas_capture, #140) -----------------------------
+// ---- Atlas capture (XR_DXR_atlas_capture, #140) -----------------------------
 
 /// App-facing atlas screenshot ('I' key / DisplayXRScreenshot): hand the runtime
 /// a path prefix + capture stage; the runtime reads back its own compositor atlas
@@ -412,16 +412,16 @@ DISPLAYXR_EXPORT int  dxr_prov_capture_atlas(const char *path_prefix, int stage)
 
 // ---- Event consumption (atomic read-and-clear; pumped by dxr_prov_poll_events) --
 
-/// Returns 1 once after a XrEventDataRenderingModeChangedEXT, filling the
+/// Returns 1 once after a XrEventDataRenderingModeChangedDXR, filling the
 /// previous/current modeIndex; 0 otherwise. The native side has already
 /// re-enumerated modes + re-derived tiling/resolution by the time this returns 1.
 DISPLAYXR_EXPORT int  dxr_prov_consume_mode_changed(uint32_t *prev_index, uint32_t *cur_index);
 
-/// Returns 1 once after a XrEventDataHardwareDisplayStateChangedEXT, filling the
+/// Returns 1 once after a XrEventDataHardwareDisplayStateChangedDXR, filling the
 /// new hardwareDisplay3D state; 0 otherwise.
 DISPLAYXR_EXPORT int  dxr_prov_consume_hw_state_changed(int *hw3d);
 
-/// Returns 1 once after a XrEventDataEyeTrackingStateChangedEXT, filling the new
+/// Returns 1 once after a XrEventDataEyeTrackingStateChangedDXR, filling the new
 /// isTracking state and activeMode (0=MANAGED, 1=MANUAL); 0 otherwise.
 DISPLAYXR_EXPORT int  dxr_prov_consume_eye_tracking_changed(int *is_tracking, int *active_mode);
 


### PR DESCRIPTION
## ⛔ DO NOT MERGE until KhronosGroup/OpenXR-Docs#199 lands — part of DisplayXR/displayxr-runtime#734

- All 13 DisplayXR-authored extensions renamed via `scripts/dxr_rename.py` (exact-symbol rules; upstream `XR_EXT_*`/`XR_KHR_*` untouched — verified by before/after inventory diff).
- Struct-type numeric block `1000999xxx` → `1004999xxx` (no hardcoded copies existed in C#; native uses the header values).
- No vendored `XR_EXT_*.h` header copies in this repo (extensions declared in `native~/displayxr_extensions.h`, rewritten in place) and no FetchContent/workflow pins of displayxr-{common,mcp,runtime,extensions} — nothing to repin.
- `XR_EXT_display_rendering_mode` in CHANGELOG.md is historical prose for a retired name, intentionally untouched.

**⚠️ Prebuilt binaries are stale until re-released:** the signed `Runtime/Plugins/Windows/x64/displayxr_unity.dll` and `Runtime/Plugins/macOS/displayxr_unity.bundle` checked into the package are built from the *old* native source and still advertise `XR_EXT_*`. After merge, run `/dxr-release unity` to rebuild + re-sign from the renamed source — a repo-only rename ships stale binaries. (The Khronos `RuntimeLoaders~/macos/openxr_loader.dylib` is upstream and unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)