### PR TITLE
Add Face Viewer (Billboard) sample

### DIFF
--- a/Samples~/FaceViewer/FaceViewer.cs
+++ b/Samples~/FaceViewer/FaceViewer.cs
@@ -1,0 +1,88 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: Apache-2.0
+
+using UnityEngine;
+
+namespace DisplayXR
+{
+    /// <summary>
+    /// Billboard component: rotates this GameObject so it always faces the
+    /// tracked viewer's head. The head position is derived from the active
+    /// rig camera's stereo view matrices — the same per-eye poses the
+    /// display provider renders with — so the object tracks the real viewer
+    /// as they move in front of the display (not just the camera transform).
+    ///
+    /// Falls back to the active camera's transform position when no stereo
+    /// data is available (provider not running, viewer not tracked yet), so
+    /// the object still behaves sensibly in 2D mode and plain Play Mode.
+    ///
+    /// Attach to any world-space object (label quad, avatar, UI panel).
+    /// Works in Play Mode and built players.
+    /// </summary>
+    [AddComponentMenu("DisplayXR/Face Viewer (Billboard)")]
+    [DefaultExecutionOrder(100)] // after the rig components' LateUpdate
+    public class FaceViewer : MonoBehaviour
+    {
+        [Tooltip("Only rotate around the world Y axis (upright billboard). " +
+                 "Good for labels and standing avatars; disable for full " +
+                 "3-axis facing (e.g. floating panels).")]
+        public bool yawOnly = false;
+
+        [Tooltip("Turn rate in degrees per second. 0 = snap instantly.")]
+        public float turnSpeed = 0f;
+
+        [Tooltip("When true, the object's +Z axis points AWAY from the viewer " +
+                 "(correct for Unity UI, TextMesh and Quad primitives, whose " +
+                 "visible face looks down -Z). When false, +Z points toward " +
+                 "the viewer.")]
+        public bool forwardAwayFromViewer = true;
+
+        void LateUpdate()
+        {
+            var cam = DisplayXRRigManager.ActiveCamera;
+            if (cam == null) cam = Camera.main;
+            if (cam == null) return;
+
+            if (!TryGetViewerHead(cam, out Vector3 head))
+                head = cam.transform.position;
+
+            Vector3 dir = forwardAwayFromViewer
+                ? transform.position - head
+                : head - transform.position;
+            if (yawOnly) dir.y = 0f;
+            if (dir.sqrMagnitude < 1e-8f) return;
+
+            Quaternion target = Quaternion.LookRotation(dir.normalized, Vector3.up);
+            transform.rotation = turnSpeed <= 0f
+                ? target
+                : Quaternion.RotateTowards(transform.rotation, target,
+                                           turnSpeed * Time.deltaTime);
+        }
+
+        /// <summary>
+        /// World-space viewer head position (midpoint of the two rendered
+        /// eyes), read from the camera's stereo view matrices. Returns false
+        /// when no usable stereo data is available — stereo inactive, or the
+        /// matrices are degenerate (identity / both eyes equal), which happens
+        /// before the runtime has tracked a viewer.
+        /// </summary>
+        public static bool TryGetViewerHead(Camera cam, out Vector3 head)
+        {
+            head = default;
+            if (cam == null || !cam.stereoEnabled) return false;
+
+            Vector3 eyeL = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Left)
+                              .inverse.GetColumn(3);
+            Vector3 eyeR = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Right)
+                              .inverse.GetColumn(3);
+
+            // Degenerate: both eyes coincident means the provider hasn't
+            // delivered real per-eye poses yet (identity matrices, or a
+            // head-center-only session).
+            if ((eyeL - eyeR).sqrMagnitude < 1e-10f) return false;
+
+            head = (eyeL + eyeR) * 0.5f;
+            return true;
+        }
+    }
+}

--- a/Samples~/FaceViewer/README.md
+++ b/Samples~/FaceViewer/README.md
@@ -1,0 +1,45 @@
+# Face Viewer (Billboard)
+
+Rotates a GameObject so it always faces the tracked viewer's head — a billboard effect driven by the **real eye-tracked viewer position**, not just the camera transform. As the user moves left/right in front of the display, the object turns to follow them.
+
+## How to use
+
+1. Package Manager → DisplayXR → Samples → "Face Viewer (Billboard)" → **Import**.
+2. The script lands at `Assets/Samples/DisplayXR/<version>/Face Viewer (Billboard)/FaceViewer.cs`.
+3. Attach `FaceViewer` to any world-space object (label quad, avatar, floating panel).
+4. Press Play on a tracking display — the object follows your head.
+
+## Inspector fields
+
+- `yawOnly` — rotate only around world Y (upright billboard). Enable for labels and standing avatars; leave off for full 3-axis facing.
+- `turnSpeed` — degrees per second toward the target orientation; `0` snaps instantly.
+- `forwardAwayFromViewer` — when true (default) the object's +Z points *away* from the viewer, which is correct for Unity UI, TextMesh, and Quad primitives (their visible face looks down −Z). Disable to point +Z at the viewer instead.
+
+## How it works
+
+The viewer's head is the midpoint of the two rendered eye positions, read from the active rig camera's stereo view matrices:
+
+```csharp
+Vector3 eyeL = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Left).inverse.GetColumn(3);
+Vector3 eyeR = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Right).inverse.GetColumn(3);
+Vector3 head = (eyeL + eyeR) * 0.5f;
+```
+
+These are the exact per-eye poses the display provider renders with (runtime-owned Kooima via `XR_DXR_view_rig`), so the billboard is always consistent with what the viewer actually sees. When no stereo data is available — provider not running, viewer not tracked yet, 2D mode — the component falls back to the camera's transform position, so behavior stays sensible everywhere.
+
+`FaceViewer.TryGetViewerHead(cam, out head)` is public and static — reuse it for your own head-coupled effects (proximity triggers, lean-to-zoom, parallax UI).
+
+## Physical-space alternative (advanced)
+
+If you need the viewer position in **real-world meters relative to the screen or window** (independent of the rig's world mapping and tunables), the plugin exposes the raw tracker data:
+
+- `DisplayXRNative.displayxr_get_eye_positions(...)` — raw per-eye positions from the last `xrLocateViews`: meters, origin at the physical panel center, +X right, +Y up, viewer at +Z.
+- `DisplayXRProvider.TryGetDisplayInfo(out info)` — physical panel size (meters) and resolution.
+- `DisplayXRNative.displayxr_get_kooima_canvas(...)` — the window's rect on the panel (panel pixels) and physical size (meters), published every frame; use it to rebase panel-center-relative eyes to window-relative.
+
+For world-space billboarding, the stereo-view-matrix route above is simpler and already consistent with rendering — reach for the raw APIs only when the effect must be expressed in physical units.
+
+## Cross-references
+
+- `DisplayXRRigManager.ActiveCamera` (plugin Runtime) — the active rig camera the component reads from
+- `DisplayXRProvider.IsEyeTracked` / `EyeTrackingStateChanged` (plugin Runtime) — whether a face is currently tracked

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
       "path": "Samples~/TransparentAvatar"
     },
     {
+      "displayName": "Face Viewer (Billboard)",
+      "description": "Billboard component that rotates an object to always face the tracked viewer's head, derived from the rendered stereo eye poses (with camera-transform fallback). README covers the head-position helper and the raw physical-space eye/window APIs for advanced head-coupled effects.",
+      "path": "Samples~/FaceViewer"
+    },
+    {
       "displayName": "Minimal Transparent",
       "description": "Smallest working alpha-native transparent overlay scene (~60 lines). Teaching sample — README walks through the three-mechanism pipeline, the OpenXR extensions in use, and the layer ownership map. Windows + macOS standalone.",
       "path": "Samples~/MinimalTransparent"


### PR DESCRIPTION
## Summary
- New UPM sample **Face Viewer (Billboard)**: `FaceViewer` component rotates any world-space object to always face the tracked viewer's head.
- Head position = midpoint of the two rendered eye positions read from the active rig camera's stereo view matrices (the exact poses the provider renders with), with a camera-transform fallback when stereo data isn't available (2D mode, viewer not tracked yet).
- Inspector options: `yawOnly` (upright billboard), `turnSpeed` (smoothed turning), `forwardAwayFromViewer` (UI/Quad-friendly default).
- Public static `FaceViewer.TryGetViewerHead(cam, out head)` for app-side head-coupled effects.
- README documents the raw physical-space alternatives (`displayxr_get_eye_positions`, `TryGetDisplayInfo`, `displayxr_get_kooima_canvas`) for effects that need real-world meters relative to the screen/window.
- Registered in `package.json` samples list.

## Test plan
- C#-only sample addition (lazy-imported via `Samples~/`, not compiled by the plugin itself). Verify by importing the sample in a host project and attaching `FaceViewer` to a quad on a tracking display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014J3K3e9gVaDLfkykJ1v8om