### PR TITLE
Face Viewer: read the head from the provider, not Camera.GetStereoViewMatrix (#236)

### DIFF
--- a/Runtime/Provider/DisplayXRProvider.cs
+++ b/Runtime/Provider/DisplayXRProvider.cs
@@ -34,10 +34,10 @@ namespace DisplayXR
 
         /// <summary>
         /// Latest eye-tracking state, cached from <see cref="EyeTrackingStateChanged"/>
-        /// (the runtime emits an edge on session start). The provider exposes no eye
-        /// positions — only whether a face is currently tracked — so editor runtime
-        /// status can surface tracked/not-tracked in provider mode. False until the
-        /// first edge / when the provider isn't running.
+        /// (the runtime emits an edge on session start) — whether a face is currently
+        /// tracked, so editor runtime status can surface tracked/not-tracked in provider
+        /// mode. For the tracked eye *positions* see <see cref="TryGetViewerEyes"/>.
+        /// False until the first edge / when the provider isn't running.
         /// </summary>
         public static bool IsEyeTracked { get; private set; }
 
@@ -90,6 +90,67 @@ namespace DisplayXR
             if (!IsRunning) return false;
             DisplayXRProviderNative.dxr_prov_get_display_info(out info);
             return info.isValid != 0;
+        }
+
+        /// <summary>
+        /// World-space positions of the two eyes the provider is rendering with this
+        /// frame (Unity coords) — the render-ready per-eye poses from
+        /// <c>xrLocateViews</c> after the runtime's Kooima math (<c>XR_DXR_view_rig</c>),
+        /// so they are always consistent with what the viewer actually sees.
+        ///
+        /// Use this — NOT <c>Camera.GetStereoViewMatrix()</c> — for head-coupled
+        /// effects. Unity's C#-side stereo matrix cache is only written by
+        /// <c>Camera.SetStereoViewMatrix()</c>, which the plugin no longer calls: in
+        /// provider mode the per-eye poses reach Unity through the native frame desc
+        /// (<c>deviceAnchorToEyePose</c>) and are consumed inside Unity's render loop,
+        /// never round-tripped back into that cache. So <c>GetStereoViewMatrix</c>
+        /// returns the same (mono) matrix for both eyes (#236).
+        ///
+        /// Returns false when the provider isn't running, or the two eyes are still
+        /// coincident (no located views yet) — fall back to the camera transform.
+        /// </summary>
+        public static bool TryGetViewerEyes(out Vector3 left, out Vector3 right)
+        {
+            left = default;
+            right = default;
+            if (s_NativeMissing) return false;
+            Vector3 l = default, r = default;
+            try
+            {
+                if (!IsRunning) return false;
+                DisplayXRProviderNative.dxr_prov_get_eye_clip(0, out _, out float lx, out float ly, out float lz);
+                DisplayXRProviderNative.dxr_prov_get_eye_clip(1, out _, out float rx, out float ry, out float rz);
+                l = new Vector3(lx, ly, lz);
+                r = new Vector3(rx, ry, rz);
+            }
+            // Head-coupled effects call this every frame, so a project without the
+            // native plugin (unsupported platform) must not throw per-frame — latch
+            // and go quiet, mirroring DisplayXRGizmoHelpers.TryGetLiveRawEyes.
+            catch (DllNotFoundException) { s_NativeMissing = true; return false; }
+            catch (EntryPointNotFoundException) { s_NativeMissing = true; return false; }
+
+            // Coincident eyes = the provider hasn't delivered real per-eye views yet
+            // (pre-first-frame zeros, or a head-center-only session).
+            if ((l - r).sqrMagnitude < 1e-10f) return false;
+            left = l;
+            right = r;
+            return true;
+        }
+
+        /// <summary>Latched once the native plugin turns out to be absent, so
+        /// <see cref="TryGetViewerEyes"/> stops throwing on every frame.</summary>
+        static bool s_NativeMissing;
+
+        /// <summary>
+        /// World-space viewer head position: the midpoint of
+        /// <see cref="TryGetViewerEyes"/>. Returns false on the same conditions.
+        /// </summary>
+        public static bool TryGetViewerHead(out Vector3 head)
+        {
+            head = default;
+            if (!TryGetViewerEyes(out Vector3 l, out Vector3 r)) return false;
+            head = (l + r) * 0.5f;
+            return true;
         }
 
         /// <summary>

--- a/Samples~/FaceViewer/FaceViewer.cs
+++ b/Samples~/FaceViewer/FaceViewer.cs
@@ -7,14 +7,15 @@ namespace DisplayXR
 {
     /// <summary>
     /// Billboard component: rotates this GameObject so it always faces the
-    /// tracked viewer's head. The head position is derived from the active
-    /// rig camera's stereo view matrices — the same per-eye poses the
-    /// display provider renders with — so the object tracks the real viewer
-    /// as they move in front of the display (not just the camera transform).
+    /// tracked viewer's head. The head position comes from
+    /// <see cref="DisplayXRProvider.TryGetViewerHead"/> — the midpoint of the
+    /// render-ready per-eye poses the display provider is drawing with — so the
+    /// object tracks the real viewer as they move in front of the display (not
+    /// just the camera transform).
     ///
-    /// Falls back to the active camera's transform position when no stereo
-    /// data is available (provider not running, viewer not tracked yet), so
-    /// the object still behaves sensibly in 2D mode and plain Play Mode.
+    /// Falls back to the active camera's transform position when no viewer data
+    /// is available (provider not running, viewer not tracked yet), so the
+    /// object still behaves sensibly in 2D mode and plain Play Mode.
     ///
     /// Attach to any world-space object (label quad, avatar, UI panel).
     /// Works in Play Mode and built players.
@@ -60,29 +61,21 @@ namespace DisplayXR
         }
 
         /// <summary>
-        /// World-space viewer head position (midpoint of the two rendered
-        /// eyes), read from the camera's stereo view matrices. Returns false
-        /// when no usable stereo data is available — stereo inactive, or the
-        /// matrices are degenerate (identity / both eyes equal), which happens
-        /// before the runtime has tracked a viewer.
+        /// World-space viewer head position (midpoint of the two rendered eyes).
+        /// Returns false when the provider isn't running or hasn't delivered real
+        /// per-eye views yet (viewer not tracked, 2D mode) — the caller should
+        /// fall back to the camera transform.
+        ///
+        /// <paramref name="cam"/> is unused and kept for source compatibility
+        /// with the v2.8.3 signature.
+        ///
+        /// Do NOT reach for <c>cam.GetStereoViewMatrix()</c> here: Unity's C#-side
+        /// stereo matrix cache is only written by <c>SetStereoViewMatrix()</c>,
+        /// which the plugin doesn't call in provider mode — it returns the same
+        /// mono matrix for both eyes, so the head never moves (#236). The
+        /// provider's own per-eye data is the source of truth.
         /// </summary>
-        public static bool TryGetViewerHead(Camera cam, out Vector3 head)
-        {
-            head = default;
-            if (cam == null || !cam.stereoEnabled) return false;
-
-            Vector3 eyeL = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Left)
-                              .inverse.GetColumn(3);
-            Vector3 eyeR = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Right)
-                              .inverse.GetColumn(3);
-
-            // Degenerate: both eyes coincident means the provider hasn't
-            // delivered real per-eye poses yet (identity matrices, or a
-            // head-center-only session).
-            if ((eyeL - eyeR).sqrMagnitude < 1e-10f) return false;
-
-            head = (eyeL + eyeR) * 0.5f;
-            return true;
-        }
+        public static bool TryGetViewerHead(Camera cam, out Vector3 head) =>
+            DisplayXRProvider.TryGetViewerHead(out head);
     }
 }

--- a/Samples~/FaceViewer/README.md
+++ b/Samples~/FaceViewer/README.md
@@ -17,17 +17,20 @@ Rotates a GameObject so it always faces the tracked viewer's head — a billboar
 
 ## How it works
 
-The viewer's head is the midpoint of the two rendered eye positions, read from the active rig camera's stereo view matrices:
+The viewer's head is the midpoint of the two eye positions the provider is rendering with, read straight from the plugin:
 
 ```csharp
-Vector3 eyeL = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Left).inverse.GetColumn(3);
-Vector3 eyeR = cam.GetStereoViewMatrix(Camera.StereoscopicEye.Right).inverse.GetColumn(3);
-Vector3 head = (eyeL + eyeR) * 0.5f;
+if (DisplayXRProvider.TryGetViewerHead(out Vector3 head)) { /* world-space head */ }
+
+// or both eyes, e.g. for per-eye effects:
+DisplayXRProvider.TryGetViewerEyes(out Vector3 eyeL, out Vector3 eyeR);
 ```
 
-These are the exact per-eye poses the display provider renders with (runtime-owned Kooima via `XR_DXR_view_rig`), so the billboard is always consistent with what the viewer actually sees. When no stereo data is available — provider not running, viewer not tracked yet, 2D mode — the component falls back to the camera's transform position, so behavior stays sensible everywhere.
+These are the exact per-eye poses the display provider renders with (runtime-owned Kooima via `XR_DXR_view_rig`), in Unity world space, so the billboard is always consistent with what the viewer actually sees. When no viewer data is available — provider not running, viewer not tracked yet, 2D mode — both calls return false and the component falls back to the camera's transform position, so behavior stays sensible everywhere.
 
-`FaceViewer.TryGetViewerHead(cam, out head)` is public and static — reuse it for your own head-coupled effects (proximity triggers, lean-to-zoom, parallax UI).
+`FaceViewer.TryGetViewerHead(cam, out head)` is public and static — reuse it for your own head-coupled effects (proximity triggers, lean-to-zoom, parallax UI) — though app code is better off calling `DisplayXRProvider.TryGetViewerHead` directly.
+
+> **Do not use `Camera.GetStereoViewMatrix()` for this.** Unity's C#-side stereo matrix cache is only written by `Camera.SetStereoViewMatrix()`, which the plugin does not call in provider mode — the per-eye poses reach Unity through the native frame desc (`deviceAnchorToEyePose`) and are consumed inside Unity's render loop, never round-tripped back into that cache. `GetStereoViewMatrix` therefore returns the same (mono) matrix for both eyes and the head never moves. The v2.8.3 version of this sample got that wrong ([#236](https://github.com/DisplayXR/displayxr-unity/issues/236)).
 
 ## Physical-space alternative (advanced)
 
@@ -37,9 +40,10 @@ If you need the viewer position in **real-world meters relative to the screen or
 - `DisplayXRProvider.TryGetDisplayInfo(out info)` — physical panel size (meters) and resolution.
 - `DisplayXRNative.displayxr_get_kooima_canvas(...)` — the window's rect on the panel (panel pixels) and physical size (meters), published every frame; use it to rebase panel-center-relative eyes to window-relative.
 
-For world-space billboarding, the stereo-view-matrix route above is simpler and already consistent with rendering — reach for the raw APIs only when the effect must be expressed in physical units.
+For world-space billboarding, `DisplayXRProvider.TryGetViewerHead` above is simpler and already consistent with rendering — reach for the raw APIs only when the effect must be expressed in physical units.
 
 ## Cross-references
 
 - `DisplayXRRigManager.ActiveCamera` (plugin Runtime) — the active rig camera the component reads from
+- `DisplayXRProvider.TryGetViewerHead` / `TryGetViewerEyes` (plugin Runtime) — the world-space viewer position this component is built on
 - `DisplayXRProvider.IsEyeTracked` / `EyeTrackingStateChanged` (plugin Runtime) — whether a face is currently tracked


### PR DESCRIPTION
Fixes #236.

## The bug

The **Face Viewer (Billboard)** sample shipped in v2.8.3 read the viewer head from `Camera.GetStereoViewMatrix(Left/Right)`. @gzq87 reported both eyes return the **same matrix** — correct, and it's structural, not a matrix bug:

Unity's C#-side stereo matrix cache is only written by `Camera.SetStereoViewMatrix()`, and the plugin no longer calls it anywhere (that was the hook-era BiRP shim, gone with #166). In provider mode the per-eye poses reach Unity through the native frame desc (`deviceAnchorToEyePose`, `set_eye_pose_rig_relative`) and are consumed inside Unity's render loop — never round-tripped back into the C# camera. So `GetStereoViewMatrix` hands back the mono view matrix twice, the sample's coincident-eyes guard tripped every frame, and the billboard fell back to the camera transform **forever**. It never tracked a head, on any pipeline or graphics API. The sample was authored without an on-hardware run.

## The fix

The provider already publishes render-ready per-eye positions in Unity world space (`dxr_prov_get_eye_clip`) — the same data the shipped URP foreground clip renders with, so it's already hardware-proven. It just had no app-facing wrapper.

- **New:** `DisplayXRProvider.TryGetViewerEyes(out left, out right)` and `TryGetViewerHead(out head)`. World-space, live per frame, false when the provider isn't running or the eyes are still coincident. A missing native plugin is latched once rather than throwing per frame (mirrors `DisplayXRGizmoHelpers.TryGetLiveRawEyes`) — head-coupled effects call this every frame, and the sample must stay safe in projects that don't ship the DLL.
- `FaceViewer.TryGetViewerHead(cam, out head)` forwards to it. Signature preserved for source compatibility with v2.8.3; `cam` is now unused.
- Sample README documents the correct APIs **and** why `GetStereoViewMatrix` is the wrong tool, so the next app author doesn't repeat it.
- Drops the stale `DisplayXRProvider` doc claim that the provider exposes no eye positions.

C#-only — no native change, no binary churn.

## Test plan

- Compile-checked against Unity 6000.4.0f1 assemblies (`DisplayXRProvider.cs`, `DisplayXRProviderNative.cs`, `DisplayXRRigManager.cs`, `FaceViewer.cs` — clean).
- **On-hardware verification** lands separately as `TigerFaceViewer` in `displayxr-unity-samples` (desktop-avatar): press <kbd>F</kbd> to billboard the tiger at the tracked viewer, and its once-per-second log prints the provider head **and** the `GetStereoViewMatrix` readback with an `eyesEqual` flag — so the fix and the original defect are visible in one line. That sample PR is blocked on this landing + a release to repin against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)