### PR TITLE
Linux VK bring-up: hardware-verified stereo on the Odyssey (#249)

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -186,14 +186,33 @@ jobs:
             echo "export OK: $sym"
           done
 
-          # The plugin must resolve Vulkan through dlopen (displayxr_vk_loader), never
-          # by linking it — otherwise it fails to load on a box with no Vulkan ICD.
-          if readelf -d "$SO" | grep -q 'libvulkan'; then
-            echo "ERROR: .so has a hard dependency on libvulkan — it must dlopen it instead"
-            readelf -d "$SO" | grep NEEDED
+          # The plugin must resolve Vulkan and Xlib through dlopen
+          # (displayxr_vk_loader / displayxr_linux.c), never by linking them —
+          # otherwise it fails to load on a box with no Vulkan ICD or no X11.
+          for lib in libvulkan libX11; do
+            if readelf -d "$SO" | grep -q "$lib"; then
+              echo "ERROR: .so has a hard dependency on $lib — it must dlopen it instead"
+              readelf -d "$SO" | grep NEEDED
+              exit 1
+            fi
+            echo "no $lib link dependency: OK"
+          done
+
+          # NO UNRESOLVED SYMBOLS. This is the check that was missing when #249
+          # first landed: unlike MSVC and macOS's two-level namespace, a Linux
+          # shared library links happily with dangling references and only fails
+          # when the loader binds them — so CI was green on a .so that died at
+          # `undefined symbol: displayxr_is_shell_mode` inside GfxStart on the
+          # target box. The link now also passes -Wl,--no-undefined (see
+          # CMakeLists.txt), which makes this belt-and-braces; keep both, because
+          # the link flag is easy to drop by accident and this is the symptom
+          # a user would actually hit.
+          if ldd -r "$SO" 2>&1 | grep -q 'undefined symbol'; then
+            echo "ERROR: unresolved symbols in the shipped .so — it will fail to load:"
+            ldd -r "$SO" 2>&1 | grep 'undefined symbol' | sort -u
             exit 1
           fi
-          echo "no libvulkan link dependency: OK"
+          echo "no unresolved symbols: OK"
 
       - name: Upload artifact
         if: needs.DetectChanges.outputs.docs_only != 'true'

--- a/native~/CMakeLists.txt
+++ b/native~/CMakeLists.txt
@@ -139,6 +139,12 @@ if(WIN32)
     # dwmapi + advapi32: MSVC links them via #pragma comment(lib, ...) in the TUs,
     # but MinGW (the macOS cross-compile check) ignores that pragma — list them here.
     link_libraries(user32 d3d11 d3d12 dxgi dwmapi advapi32 d3dcompiler)
+elseif(UNIX AND NOT APPLE AND NOT ANDROID)
+    # Desktop-Linux platform glue (#249): the shell-mode stub the shared provider
+    # code references unconditionally (macOS ships the same stub), plus the X11
+    # helper that finds the player's own window so Linux can be a HANDLE app
+    # (XR_DXR_xlib_window_binding) like Windows and macOS.
+    list(APPEND SOURCES displayxr_linux.c)
 endif()
 
 # Provider Vulkan backend (#247 Windows, #249 Linux): enable2 session device +
@@ -250,10 +256,20 @@ else()
         LIBRARY_OUTPUT_DIRECTORY_RELEASE "${PLUGIN_OUTPUT_DIR}"
         LIBRARY_OUTPUT_DIRECTORY_DEBUG "${PLUGIN_OUTPUT_DIR}"
     )
-    # The plugin resolves every Vulkan entry point through dlopen/dlsym
-    # (displayxr_vk_loader.cpp), so it needs libdl but must NOT link libvulkan —
-    # that is what keeps the .so loadable on a box with no Vulkan ICD.
+    # The plugin resolves Vulkan AND Xlib entry points through dlopen/dlsym
+    # (displayxr_vk_loader.cpp, displayxr_linux.c), so it needs libdl but must NOT
+    # link libvulkan or libX11 — that is what keeps the .so loadable on a box with
+    # no Vulkan ICD and no X11.
     target_link_libraries(displayxr_unity PRIVATE ${CMAKE_DL_LIBS})
+
+    # --no-undefined: make an unresolved symbol a LINK ERROR instead of a runtime
+    # surprise. Learned the hard way (#249): a Linux shared library links happily
+    # with dangling references and only dies when the loader binds them, so CI
+    # reported green on a .so that could not load at all — `undefined symbol:
+    # displayxr_is_shell_mode` on the target box, inside GfxStart. Windows (MSVC)
+    # and macOS (two-level namespace) both reject this by default; Linux is the
+    # odd one out, so ask for the same strictness explicitly.
+    target_link_options(displayxr_unity PRIVATE -Wl,--no-undefined)
 endif()
 
 # --- Summary ---

--- a/native~/displayxr_extensions.h
+++ b/native~/displayxr_extensions.h
@@ -220,6 +220,33 @@ typedef struct XrCocoaWindowBindingCreateInfoDXR {
     XrBool32 transparentBackgroundEnabled; // SPEC_VERSION 5
 } XrCocoaWindowBindingCreateInfoDXR;
 
+// --- XR_DXR_xlib_window_binding (desktop Linux, #249) ---
+// Third sibling of the win32 (HWND) / cocoa (NSView) bindings: hands the runtime
+// the app's own X11 window so it weaves there instead of self-hosting one.
+//
+// Xlib types are used deliberately by the extension (Display* / Window) — the
+// runtime converts to XCB internally via XGetXCBConnection and builds its surface
+// with VK_KHR_xcb_surface. We mirror the struct with `void *` / `unsigned long`
+// rather than including <X11/Xlib.h>, for the same reason the Vulkan structs are
+// mirrored here: this TU must not acquire an X11 build dependency, and the plugin
+// resolves Xlib at runtime via dlopen (displayxr_linux.c).
+//
+// CONTRACT WORTH REMEMBERING: the Display connection must OUTLIVE the session —
+// the runtime borrows it for the lifetime of the Vulkan surface. displayxr_linux.c
+// therefore keeps its XOpenDisplay connection open for the process lifetime.
+#define XR_DXR_XLIB_WINDOW_BINDING_EXTENSION_NAME "XR_DXR_xlib_window_binding"
+#define XR_DXR_XLIB_WINDOW_BINDING_SPEC_VERSION 2
+
+#define XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_DXR_PS ((XrStructureType)1004999200)
+
+typedef struct XrXlibWindowBindingCreateInfoDXR {
+    XrStructureType type;
+    const void *next;
+    void *xDisplay;                        // Display* from XOpenDisplay
+    unsigned long window;                  // X11 Window (XID)
+    XrBool32 transparentBackgroundEnabled; // SPEC_VERSION 2
+} XrXlibWindowBindingCreateInfoDXR;
+
 // --- XR_KHR_metal_enable ---
 // Hand-defined: the fetched OpenXR-SDK release-1.0.34 headers predate the
 // Metal enable extension (it landed in the 1.1.x line), so openxr_platform.h

--- a/native~/displayxr_linux.c
+++ b/native~/displayxr_linux.c
@@ -1,0 +1,438 @@
+// Copyright 2024-2026, DisplayXR contributors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Desktop-Linux platform glue for the IUnityXRDisplay provider (#249).
+//
+// Two jobs, both mirroring what displayxr_macos.mm does for Cocoa:
+//
+//  1. Platform stubs the shared provider code references unconditionally
+//     (displayxr_is_shell_mode). macOS ships the same stub for the same reason.
+//
+//  2. Find the PLAYER'S OWN top-level X11 window, so the session can be a
+//     HANDLE app (XR_DXR_xlib_window_binding) exactly like Windows (HWND) and
+//     macOS (NSView) — the runtime weaves into Unity's window instead of
+//     creating one of its own.
+//
+// WHY WE DLOPEN libX11 RATHER THAN LINK IT
+// ----------------------------------------
+// Same policy as displayxr_vk_loader.c: the shipped .so must keep NO hard
+// DT_NEEDED on a library that might be absent (a headless or Wayland-only box),
+// and CI must not need libx11-dev. So every Xlib entry point is resolved at
+// runtime and the whole feature degrades to "no window binding" if libX11 is
+// missing — the runtime then self-hosts, which still renders.
+//
+// WHICH WINDOW THE RUNTIME WEAVES INTO — AND WHY IT IS NOT UNITY'S
+// ----------------------------------------------------------------
+// We create our OWN top-level X11 window and hand the runtime that. This mirrors
+// the other two platforms exactly: Windows passes an app-owned WS_POPUP overlay
+// (never Unity's main HWND) and macOS attaches its own overlay NSView.
+//
+// It is not a style choice — XR_DXR_xlib_window_binding says the RUNTIME renders
+// into the supplied window, so the window must not already carry a swapchain the
+// app presents to. Unity's main window does: Unity builds its own VkSwapchainKHR
+// on it at startup. Binding it was measured on the Odyssey and produced exactly
+// the pathology you would predict: a perfectly healthy session (weaver holding
+// our XID, 1800+ submitted frames, no errors) and NOTHING on the panel, because
+// the two presenters fight over one surface.
+//
+// We still LOCATE Unity's window — by walking the tree for _NET_WM_PID ==
+// getpid(), the X11 analogue of walking NSApplication — but only to place and
+// size our overlay over it.
+//
+// INPUT: this first-light overlay is an ordinary top-level window, so it takes
+// clicks that would otherwise reach Unity. The Windows overlay solves this with
+// WS_EX_NOACTIVATE + a click-through region; the X11 equivalent is an empty
+// XShape INPUT region (libXext). That is a follow-up — it needs a second dlopen
+// and does not block first light.
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "displayxr_exports.h"
+
+extern void dxr_prov_file_log(const char *s);
+
+static void
+lin_log(const char *msg)
+{
+	fputs(msg, stderr);
+	dxr_prov_file_log(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Shell-mode stub
+// ---------------------------------------------------------------------------
+
+// There is no DisplayXR Shell on Linux — the workspace/IPC tile session is a
+// Windows product feature. The shared provider code queries this predicate
+// unconditionally, so (exactly like the macOS stub) we answer a constant 0
+// rather than sprinkle #ifdefs through every call site.
+DISPLAYXR_EXPORT int
+displayxr_is_shell_mode(void)
+{
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Xlib, resolved at runtime
+// ---------------------------------------------------------------------------
+
+typedef void *XDpy;
+typedef unsigned long XWin;
+typedef unsigned long XAtom;
+
+struct XlibApi {
+	void *lib;
+	XDpy (*XOpenDisplay)(const char *);
+	int (*XCloseDisplay)(XDpy);
+	XWin (*XDefaultRootWindow)(XDpy);
+	int (*XQueryTree)(XDpy, XWin, XWin *, XWin *, XWin **, unsigned int *);
+	int (*XFree)(void *);
+	XAtom (*XInternAtom)(XDpy, const char *, int);
+	int (*XGetWindowProperty)(XDpy, XWin, XAtom, long, long, int, XAtom, XAtom *,
+	                          int *, unsigned long *, unsigned long *, unsigned char **);
+	int (*XGetGeometry)(XDpy, XWin, XWin *, int *, int *, unsigned int *,
+	                    unsigned int *, unsigned int *, unsigned int *);
+	int (*XSync)(XDpy, int);
+	// Overlay-window creation
+	XWin (*XCreateSimpleWindow)(XDpy, XWin, int, int, unsigned int, unsigned int,
+	                            unsigned int, unsigned long, unsigned long);
+	int (*XMapRaised)(XDpy, XWin);
+	int (*XRaiseWindow)(XDpy, XWin);
+	int (*XChangeWindowAttributes)(XDpy, XWin, unsigned long, void *);
+	int (*XMoveResizeWindow)(XDpy, XWin, int, int, unsigned int, unsigned int);
+	int (*XStoreName)(XDpy, XWin, const char *);
+	int (*XDestroyWindow)(XDpy, XWin);
+	int (*XFlush)(XDpy);
+	unsigned long (*XBlackPixel)(XDpy, int);
+	int (*XDefaultScreen)(XDpy);
+	int (*XTranslateCoordinates)(XDpy, XWin, XWin, int, int, int *, int *, XWin *);
+};
+
+static struct XlibApi s_x;
+static XDpy s_dpy;       // our own connection; must outlive the session
+static XWin s_win;       // the player's top-level window, 0 if not found
+static int  s_attempts;  // bounded retry — see the note in the getter
+static int  s_gave_up;   // latched only after we stop trying
+static XWin s_overlay;   // OUR window — the one the runtime weaves into
+static int  s_ox, s_oy;             // last overlay placement, to skip no-op moves
+static unsigned int s_ow, s_oh;
+
+// Don't latch a FAILURE forever. The window may simply not be mapped yet on the
+// first call (LifecycleStart can beat Unity's window creation depending on how
+// early XR initializes), and caching "not found" from that one early look would
+// permanently demote us to the self-hosted path for the whole process. Retry a
+// bounded number of times, then stop walking the tree every frame.
+#define LIN_MAX_WINDOW_SEARCHES 120
+
+#define XL_SYM(name)                                                       \
+	do {                                                                   \
+		*(void **)(&s_x.name) = dlsym(s_x.lib, #name);                     \
+		if (!s_x.name) {                                                   \
+			lin_log("[DisplayXR-LNX] libX11 missing symbol " #name "\n");  \
+			return 0;                                                      \
+		}                                                                  \
+	} while (0)
+
+static int
+lin_load_xlib(void)
+{
+	if (s_x.lib) return 1;
+	// SONAME, not the -dev symlink: a runtime box has libX11.so.6 but usually
+	// not the unversioned libX11.so.
+	s_x.lib = dlopen("libX11.so.6", RTLD_NOW | RTLD_LOCAL);
+	if (!s_x.lib) s_x.lib = dlopen("libX11.so", RTLD_NOW | RTLD_LOCAL);
+	if (!s_x.lib) {
+		lin_log("[DisplayXR-LNX] libX11 not present — no window binding; the runtime "
+		        "will self-host its weave window\n");
+		return 0;
+	}
+	XL_SYM(XOpenDisplay);
+	XL_SYM(XCloseDisplay);
+	XL_SYM(XDefaultRootWindow);
+	XL_SYM(XQueryTree);
+	XL_SYM(XFree);
+	XL_SYM(XInternAtom);
+	XL_SYM(XGetWindowProperty);
+	XL_SYM(XGetGeometry);
+	XL_SYM(XSync);
+	XL_SYM(XCreateSimpleWindow);
+	XL_SYM(XMapRaised);
+	XL_SYM(XRaiseWindow);
+	XL_SYM(XChangeWindowAttributes);
+	XL_SYM(XMoveResizeWindow);
+	XL_SYM(XStoreName);
+	XL_SYM(XDestroyWindow);
+	XL_SYM(XFlush);
+	XL_SYM(XBlackPixel);
+	XL_SYM(XDefaultScreen);
+	XL_SYM(XTranslateCoordinates);
+	return 1;
+}
+
+#define XA_CARDINAL_ 6L // <X11/Xatom.h>, inlined so we need no X11 headers
+#define CW_OVERRIDE_REDIRECT_ (1L << 9) // CWOverrideRedirect from <X11/X.h>
+
+// Binary mirror of Xlib's XSetWindowAttributes. We only ever set
+// override_redirect, but the field ORDER and widths must match exactly — this is
+// an ancient, frozen Xlib ABI, mirrored here for the same reason the OpenXR and
+// Vulkan structs are: so this TU acquires no X11 build dependency.
+struct DxrXSetWindowAttributes {
+	unsigned long background_pixmap;
+	unsigned long background_pixel;
+	unsigned long border_pixmap;
+	unsigned long border_pixel;
+	int           bit_gravity;
+	int           win_gravity;
+	int           backing_store;
+	unsigned long backing_planes;
+	unsigned long backing_pixel;
+	int           save_under;          // Bool
+	long          event_mask;
+	long          do_not_propagate_mask;
+	int           override_redirect;   // Bool — the only field we set
+	unsigned long colormap;
+	unsigned long cursor;
+};
+
+// Read _NET_WM_PID off `w`. 0 when the property is absent.
+static pid_t
+lin_window_pid(XWin w, XAtom pid_atom)
+{
+	XAtom actual_type = 0;
+	int actual_format = 0;
+	unsigned long nitems = 0, bytes_after = 0;
+	unsigned char *prop = NULL;
+	pid_t out = 0;
+
+	if (s_x.XGetWindowProperty(s_dpy, w, pid_atom, 0, 1, 0, (XAtom)XA_CARDINAL_,
+	                           &actual_type, &actual_format, &nitems, &bytes_after,
+	                           &prop) != 0 /* Success == 0 */)
+		return 0;
+	if (prop) {
+		if (nitems >= 1 && actual_format == 32) out = (pid_t)(*(unsigned long *)prop);
+		s_x.XFree(prop);
+	}
+	return out;
+}
+
+// Bounded BFS from the root, keeping the largest PID-matching window.
+static void
+lin_scan(XWin root, XAtom pid_atom, pid_t self, int depth, XWin *best, unsigned long *best_area)
+{
+	if (depth > 3) return;
+
+	XWin r = 0, parent = 0, *kids = NULL;
+	unsigned int nkids = 0;
+	if (!s_x.XQueryTree(s_dpy, root, &r, &parent, &kids, &nkids) || !kids) return;
+
+	for (unsigned int i = 0; i < nkids; i++) {
+		if (lin_window_pid(kids[i], pid_atom) == self) {
+			XWin gr = 0;
+			int gx = 0, gy = 0;
+			unsigned int gw = 0, gh = 0, gb = 0, gd = 0;
+			if (s_x.XGetGeometry(s_dpy, kids[i], &gr, &gx, &gy, &gw, &gh, &gb, &gd)) {
+				unsigned long area = (unsigned long)gw * (unsigned long)gh;
+				// Ignore 1x1 / icon-sized helper windows.
+				if (gw > 16 && gh > 16 && area > *best_area) {
+					*best_area = area;
+					*best = kids[i];
+				}
+			}
+		}
+		lin_scan(kids[i], pid_atom, self, depth + 1, best, best_area);
+	}
+	s_x.XFree(kids);
+}
+
+// Find (once) the player's own top-level X11 window.
+// Returns 1 and fills the out-params on success. The Display connection is
+// owned by this TU and intentionally kept open for the process lifetime — the
+// runtime borrows it for the Vulkan surface (see the extension header).
+DISPLAYXR_EXPORT int
+displayxr_linux_get_app_window(void **out_display, unsigned long *out_window)
+{
+	if (!s_win && !s_gave_up) {
+		if (!lin_load_xlib()) {
+			s_gave_up = 1; // no libX11 — retrying cannot help
+		} else {
+			if (!s_dpy) {
+				s_dpy = s_x.XOpenDisplay(NULL);
+				if (!s_dpy) {
+					lin_log("[DisplayXR-LNX] XOpenDisplay failed (DISPLAY unset?) — no window "
+					        "binding; the runtime will self-host its weave window\n");
+					s_gave_up = 1; // no display — retrying cannot help either
+				}
+			}
+			if (s_dpy) {
+				// A sync makes sure the tree we walk reflects what the server has;
+				// Unity's window may have been created moments ago.
+				s_x.XSync(s_dpy, 0);
+				XWin root = s_x.XDefaultRootWindow(s_dpy);
+				XAtom pid_atom = s_x.XInternAtom(s_dpy, "_NET_WM_PID", 1 /*only_if_exists*/);
+				unsigned long best_area = 0;
+				if (pid_atom) lin_scan(root, pid_atom, getpid(), 0, &s_win, &best_area);
+
+				if (s_win) {
+					char m[192];
+					snprintf(m, sizeof(m),
+					         "[DisplayXR-LNX] bound app X11 window 0x%lx (%lu px area, pid %d, "
+					         "after %d search(es))\n",
+					         (unsigned long)s_win, best_area, (int)getpid(), s_attempts + 1);
+					lin_log(m);
+				} else if (++s_attempts >= LIN_MAX_WINDOW_SEARCHES) {
+					char m[192];
+					snprintf(m, sizeof(m),
+					         "[DisplayXR-LNX] no _NET_WM_PID window matched pid %d after %d "
+					         "searches — giving up; the runtime will self-host its weave "
+					         "window\n", (int)getpid(), s_attempts);
+					lin_log(m);
+					s_gave_up = 1;
+				}
+			}
+		}
+	}
+	if (!s_dpy || !s_win) return 0;
+	if (out_display) *out_display = s_dpy;
+	if (out_window) *out_window = (unsigned long)s_win;
+	return 1;
+}
+
+// Absolute screen geometry of Unity's window (its own coordinates are relative to
+// whatever the WM reparented it into, so translate against the root).
+static int
+lin_unity_geometry(int *out_x, int *out_y, unsigned int *out_w, unsigned int *out_h)
+{
+	if (!s_dpy || !s_win) return 0;
+	XWin gr = 0, child = 0;
+	int gx = 0, gy = 0, ax = 0, ay = 0;
+	unsigned int gw = 0, gh = 0, gb = 0, gd = 0;
+	if (!s_x.XGetGeometry(s_dpy, s_win, &gr, &gx, &gy, &gw, &gh, &gb, &gd)) return 0;
+	if (!s_x.XTranslateCoordinates(s_dpy, s_win, gr, 0, 0, &ax, &ay, &child)) { ax = gx; ay = gy; }
+	*out_x = ax; *out_y = ay; *out_w = gw; *out_h = gh;
+	return 1;
+}
+
+// Create (once) the PLUGIN-OWNED overlay window the runtime weaves into, sized and
+// positioned over Unity's window. Returns 1 and fills the out-params on success.
+//
+// The Display connection is intentionally kept open for the process lifetime —
+// the runtime borrows it for the Vulkan surface (see the extension header).
+DISPLAYXR_EXPORT int
+displayxr_linux_get_weave_window(void **out_display, unsigned long *out_window)
+{
+	if (!s_overlay) {
+		void *dpy = NULL;
+		unsigned long unity_win = 0;
+		if (!displayxr_linux_get_app_window(&dpy, &unity_win)) return 0;
+
+		int x = 0, y = 0;
+		unsigned int w = 0, h = 0;
+		if (!lin_unity_geometry(&x, &y, &w, &h)) { x = 0; y = 0; w = 1920; h = 1080; }
+
+		XWin root = s_x.XDefaultRootWindow(s_dpy);
+		int scr = s_x.XDefaultScreen(s_dpy);
+		// Background MAGENTA, deliberately, not black: it separates "the runtime never
+		// presented" (window stays magenta) from "the runtime presented black frames"
+		// (window goes black). With a black background those two look identical, which
+		// cost a debugging cycle on the Odyssey. DISPLAYXR_LNX_OVERLAY_BG=black opts out.
+		unsigned long bg = 0x00FF00FF; // magenta in the usual 24-bit TrueColor visual
+		const char *bgenv = getenv("DISPLAYXR_LNX_OVERLAY_BG");
+		if (bgenv && !strcmp(bgenv, "black")) bg = s_x.XBlackPixel(s_dpy, scr);
+		s_overlay = s_x.XCreateSimpleWindow(s_dpy, root, x, y, w, h, 0, bg, bg);
+		if (!s_overlay) {
+			lin_log("[DisplayXR-LNX] XCreateSimpleWindow failed — the runtime will self-host\n");
+			return 0;
+		}
+		s_x.XStoreName(s_dpy, s_overlay, "DisplayXR Weave");
+
+		// OVERRIDE-REDIRECT: take the window out of the window manager's hands, the
+		// X11 equivalent of the Windows overlay's WS_POPUP. XRaiseWindow alone is only
+		// a REQUEST — a reparenting WM is free to restack Unity's focused window back
+		// on top, and it does. Measured on the Odyssey: the weave was rendering
+		// correctly the whole time and was visible only as a strip along the edges
+		// Unity's window did not cover.
+		{
+			struct DxrXSetWindowAttributes attrs;
+			memset(&attrs, 0, sizeof(attrs));
+			attrs.override_redirect = 1;
+			s_x.XChangeWindowAttributes(s_dpy, s_overlay, CW_OVERRIDE_REDIRECT_, &attrs);
+		}
+		s_x.XMapRaised(s_dpy, s_overlay);
+		s_x.XFlush(s_dpy);
+		s_x.XSync(s_dpy, 0);
+
+		char m[224];
+		snprintf(m, sizeof(m),
+		         "[DisplayXR-LNX] weave overlay window 0x%lx created at %d,%d %ux%u "
+		         "(over Unity's window 0x%lx)\n",
+		         (unsigned long)s_overlay, x, y, w, h, unity_win);
+		lin_log(m);
+	}
+	if (!s_dpy || !s_overlay) return 0;
+	if (out_display) *out_display = s_dpy;
+	if (out_window) *out_window = (unsigned long)s_overlay;
+	return 1;
+}
+
+// Keep the overlay parked over Unity's window. Cheap enough to call per frame;
+// only issues X traffic when the geometry actually moved.
+DISPLAYXR_EXPORT void
+displayxr_linux_track_window(void)
+{
+	if (!s_dpy || !s_overlay || !s_win) return;
+	int x = 0, y = 0;
+	unsigned int w = 0, h = 0;
+	if (!lin_unity_geometry(&x, &y, &w, &h) || w == 0 || h == 0) return;
+	int moved = (x != s_ox || y != s_oy || w != s_ow || h != s_oh);
+	if (moved) {
+		s_ox = x; s_oy = y; s_ow = w; s_oh = h;
+		s_x.XMoveResizeWindow(s_dpy, s_overlay, x, y, w, h);
+	}
+	// RE-RAISE, every tick, not just on move. The WM restacks Unity's window above
+	// ours whenever it takes focus, and a covered overlay looks exactly like a dead
+	// weave: on the Odyssey the woven frame was live the whole time and only visible
+	// as a thin strip down the edges Unity's window did not cover. Raising is cheap
+	// (one X request) and idempotent.
+	s_x.XRaiseWindow(s_dpy, s_overlay);
+	s_x.XFlush(s_dpy);
+}
+
+// Live size of the WEAVE window, for the per-frame canvas reconcile. 0 on failure
+// so callers fall back to the display-info default.
+DISPLAYXR_EXPORT int
+displayxr_linux_window_size(uint32_t *out_w, uint32_t *out_h)
+{
+	XWin target = s_overlay ? s_overlay : s_win;
+	if (!s_dpy || !target || !s_x.XGetGeometry) return 0;
+	XWin gr = 0;
+	int gx = 0, gy = 0;
+	unsigned int gw = 0, gh = 0, gb = 0, gd = 0;
+	if (!s_x.XGetGeometry(s_dpy, target, &gr, &gx, &gy, &gw, &gh, &gb, &gd)) return 0;
+	if (gw == 0 || gh == 0) return 0;
+	if (out_w) *out_w = (uint32_t)gw;
+	if (out_h) *out_h = (uint32_t)gh;
+	return 1;
+}
+
+// Tear down the overlay. The Display connection stays open — the runtime may still
+// be unwinding its surface, and re-opening costs nothing we need back.
+DISPLAYXR_EXPORT void
+displayxr_linux_destroy_weave_window(void)
+{
+	if (s_dpy && s_overlay && s_x.XDestroyWindow) {
+		s_x.XDestroyWindow(s_dpy, s_overlay);
+		s_x.XFlush(s_dpy);
+		lin_log("[DisplayXR-LNX] weave overlay window destroyed\n");
+	}
+	s_overlay = 0;
+	s_ox = s_oy = 0; s_ow = s_oh = 0;
+}
+
+#endif // __linux__ && !__ANDROID__

--- a/native~/displayxr_xrprovider/displayxr_display_provider.cpp
+++ b/native~/displayxr_xrprovider/displayxr_display_provider.cpp
@@ -93,6 +93,12 @@ extern "C" void *displayxr_get_app_main_view(void);
 // In that mode the provider is a plain OpenXR client: no overlay, no foreground grab,
 // windowHandle=NULL. Defined in displayxr_win32.c / displayxr_macos.mm.
 extern "C" int displayxr_is_shell_mode(void);
+#if defined(__linux__) && !defined(__ANDROID__)
+// Linux handle-app glue (#249), defined in displayxr_linux.c.
+extern "C" int displayxr_linux_get_weave_window(void **out_display, unsigned long *out_window);
+extern "C" void displayxr_linux_destroy_weave_window(void);
+extern "C" void displayxr_linux_track_window(void);
+#endif
 #ifdef _WIN32
 // (#166) Make the overlay a top-level WS_POPUP+NOREDIRECTIONBITMAP (composites the
 // runtime DComp weave) instead of a WS_CHILD. Call before displayxr_get_app_main_view().
@@ -767,14 +773,19 @@ GfxStart(UnitySubsystemHandle handle, void *userData, UnityXRRenderingCapabiliti
 		caps->invalidateRenderStateAfterEachCallback = true; // we touch D3D state
 		caps->skipPresentToMainScreen = false;
 #elif defined(__linux__) && !defined(__ANDROID__)
-		// Linux/Vulkan (#249). Deliberately NOT the macOS arm below — that one is
-		// justified entirely by Metal-specific Unity defects (#204/#205) and its
-		// skipPresentToMainScreen=true would blank the player window here for no
-		// reason. Linux behaves like the Windows own-device bridge: the provider
-		// records and submits its own Vulkan command buffers, so Unity's render
-		// state must be re-validated around each callback, and Unity keeps
-		// presenting to its own window.
+		// Linux/Vulkan (#249). The provider records and submits its own Vulkan
+		// command buffers, so Unity's render state must be re-validated around each
+		// callback — same as the Windows own-device bridge.
 		caps->invalidateRenderStateAfterEachCallback = true;
+		// Unity keeps presenting to ITS OWN window — same as Windows, and for the
+		// same reason: the runtime weaves into a SEPARATE plugin-owned overlay
+		// window, so the two never contend for one surface.
+		//
+		// Measured on the Odyssey, both wrong ways round: binding Unity's own window
+		// gave a healthy session (weaver holding the XID, 1800+ frames) with a BLACK
+		// panel when Unity also presented, and an EMPTY window when it did not —
+		// because XR_DXR_xlib_window_binding hands presentation of that window to the
+		// runtime, and Unity already owns a swapchain on its main window.
 		caps->skipPresentToMainScreen = false;
 #else
 		// macOS zero-copy touches NO Unity render state in the callbacks (no
@@ -904,7 +915,16 @@ GfxStart(UnitySubsystemHandle handle, void *userData, UnityXRRenderingCapabiliti
 		             ? (prov_want_dedicated_window()
 		                    ? "[DisplayXR-PROV] weave target: dedicated provider window (editor, #173)\n"
 		                    : "[DisplayXR-PROV] weave target: app-owned top-level overlay (in-app)\n")
+#if defined(__linux__) && !defined(__ANDROID__)
+		             // Linux carries its window through the xlib binding, not through
+		             // s_overlay_hwnd (the binding needs a Display*+Window PAIR), so a
+		             // NULL handle here does NOT mean self-hosting — saying "SELFHOST"
+		             // read as a contradiction against the xlib-binding line that
+		             // follows it. The session logs the real target.
+		             : "[DisplayXR-PROV] weave target: X11 window binding (decided at session create)\n");
+#else
 		             : "[DisplayXR-PROV] weave target: runtime self-hosted window (SELFHOST diagnostic)\n");
+#endif
 	}
 
 	// runtime_json = NULL -> resolve from XR_RUNTIME_JSON (sim_display bring-up).
@@ -929,14 +949,30 @@ GfxPopulateNextFrameDesc(UnitySubsystemHandle handle, void *userData,
 
 	if (!s_session_active) return kUnitySubsystemErrorCodeSuccess;
 
-#ifdef _WIN32
+#if defined(_WIN32) || (defined(__linux__) && !defined(__ANDROID__))
+	// Windows and Linux pump xrPollEvent HERE, on the graphics thread.
+	//
+	// This is load-bearing and easy to miss: without it the READY event is never
+	// consumed, so xrBeginSession is never called, the session sits at state 2
+	// (READY) forever, shouldRender stays false, and NOTHING renders. On the Odyssey
+	// that presented as a perfectly healthy-looking run — session created, weaver
+	// holding our window, ~1800 pump ticks — with a blank panel and zero bridge
+	// copies. Linux originally inherited the macOS arm below and hit exactly that
+	// (#249); it has no AppKit constraint, so it belongs on the Windows side.
 	dxr_prov_poll_events();
+#endif
+#if defined(__linux__) && !defined(__ANDROID__)
+	// Keep the plugin-owned weave overlay parked over — and ABOVE — Unity's window.
+	// The Windows overlay does the same tracking via SetWindowPos in its WndProc.
+	displayxr_linux_track_window();
+#endif
+#ifdef _WIN32
 	// GameView zone convergence (Phase 1, #727 follow-up): re-drive the forced full-window
 	// zone to the authoritative panel px the mirror callback published, so the compositor
 	// canvas == Game-view render viewport pixel-exact. A no-op once converged; when it does
 	// change the zone, the reconcile below reallocs the swapchain/bridge to match.
 	dxr_prov_converge_gameview_zone();
-#else
+#elif defined(__APPLE__)
 	// macOS (#204): xrPollEvent is pumped from the MAIN thread instead — the
 	// runtime's oxr_macos_pump_events drains NSApp events + flushes CATransaction,
 	// both main-thread-only (AppKit throws off-main). DisplayXRProviderDriver
@@ -1717,12 +1753,24 @@ LifecycleStart(UnitySubsystemHandle handle, void *userData)
 		}
 	}
 #elif defined(__linux__) && !defined(__ANDROID__)
-	// Linux (#249 Phase 1): no window is created here. The runtime's Vulkan/XCB
-	// compositor self-hosts its own window (session binding chains no window-binding
-	// extension — see dxr_prov_session_start). Binding the player's own X11 window
-	// is the XR_DXR_xlib_window_binding follow-on.
-	s_overlay_hwnd = nullptr;
-	prov_log("[DisplayXR-PROV] Lifecycle Start (Linux: runtime self-hosted weave window)\n");
+	// Linux (#249): HANDLE app — resolve the player's own top-level X11 window here,
+	// on the main thread, before GfxStart binds the session (same ordering as the
+	// Windows overlay HWND and the macOS NSView). displayxr_linux.c caches the
+	// result; dxr_prov_session_start chains it as XR_DXR_xlib_window_binding.
+	//
+	// s_overlay_hwnd stays NULL: on Windows/macOS it carries the native window the
+	// session binds, but the xlib binding needs a (Display*, Window) PAIR that does
+	// not fit one pointer — so the session pulls both from displayxr_linux.c rather
+	// than through this field.
+	{
+		void *xdpy = nullptr;
+		unsigned long xwin = 0;
+		bool have = displayxr_linux_get_weave_window(&xdpy, &xwin) != 0;
+		s_overlay_hwnd = nullptr;
+		prov_log(have
+		             ? "[DisplayXR-PROV] Lifecycle Start (Linux: plugin-owned overlay weave window)\n"
+		             : "[DisplayXR-PROV] Lifecycle Start (Linux: no overlay window — runtime self-hosted weave window)\n");
+	}
 #else
 	if (displayxr_is_shell_mode()) {
 		// Workspace tile (shell/IPC). The Shell launched us with
@@ -1885,7 +1933,10 @@ LifecycleStop(UnitySubsystemHandle handle, void *userData)
 	displayxr_metal_destroy_preview_window();  // editor / fallback window
 	s_overlay_hwnd = nullptr;
 #else
-	// Linux (#249): no provider-owned window to tear down — the runtime self-hosts.
+	// Linux (#249): drop the plugin-owned overlay on the MAIN thread, after GfxStop
+	// already ran dxr_prov_session_stop (xrDestroySession released the runtime's
+	// surface on it) — same ordering rule as the #173 Windows / #204 macOS teardown.
+	displayxr_linux_destroy_weave_window();
 	s_overlay_hwnd = nullptr;
 #endif
 	prov_log("[DisplayXR-PROV] Lifecycle Stop\n");

--- a/native~/displayxr_xrprovider/displayxr_provider_gfx_vulkan.cpp
+++ b/native~/displayxr_xrprovider/displayxr_provider_gfx_vulkan.cpp
@@ -1102,6 +1102,17 @@ dxr_pvk_copy_to_swapchain_image(int eye, uint32_t image_index)
 	}
 	// xrReleaseSwapchainImage must not run before the copy lands.
 	s_pvk.api.vkWaitForFences(s_pvk.device, 1, &s_pvk.copy_fence, VK_TRUE, UINT64_MAX);
+
+	// Periodic proof-of-life for the bridge copy. Without it, "the panel is black"
+	// is ambiguous between "the runtime never presented", "it presented black" and
+	// "we never copied" — three very different bugs that look identical from the
+	// outside. Cheap: one line per 600 copies.
+	{
+		static unsigned long copies = 0;
+		if ((copies++ % 600) == 0)
+			pvk_log("[DisplayXR-PROV-VK] bridge copy #%lu OK (eye=%d img=%u %ux%u)\n",
+			        copies, eye, image_index, b->width, b->height);
+	}
 	return 1;
 }
 

--- a/native~/displayxr_xrprovider/displayxr_provider_session.cpp
+++ b/native~/displayxr_xrprovider/displayxr_provider_session.cpp
@@ -885,7 +885,18 @@ static void ps_active_view_scale(float *sx, float *sy)
 	*sx = x; *sy = y;
 }
 
-extern "C" int displayxr_is_shell_mode(void); // defined in displayxr_win32.c
+// Per-platform: displayxr_win32.c / displayxr_macos.mm / displayxr_linux.c.
+// Every platform MUST define it — the shared code below calls it unconditionally,
+// and a missing definition is an unresolved symbol the loader only reports when
+// it binds (see the --no-undefined note in CMakeLists.txt, #249).
+extern "C" int displayxr_is_shell_mode(void);
+
+#if defined(__linux__) && !defined(__ANDROID__)
+// Linux handle-app glue (#249), defined in displayxr_linux.c.
+extern "C" int displayxr_linux_get_weave_window(void **out_display, unsigned long *out_window);
+extern "C" void displayxr_linux_destroy_weave_window(void);
+extern "C" int displayxr_linux_window_size(uint32_t *out_w, uint32_t *out_h);
+#endif
 
 // Poll the live workspace-tile canvas size (#225, display_zones spec v2). The
 // compositor composites this client into a shell-driven tile that follows 3D-
@@ -943,12 +954,17 @@ static void ps_window_size(uint32_t *w, uint32_t *h)
 			hh = (uint32_t)(rc.bottom - rc.top);
 		}
 	}
-#else
+#elif defined(__APPLE__)
 	// macOS (#204): the bound weave NSView's live backing size — the same
 	// per-frame source the runtime's compositor derives its canvas from, so
 	// the per-view sizes agree and live resize lands via the #172 reconcile.
 	if (s_ps.overlay_hwnd)
 		displayxr_metal_view_backing_size(s_ps.overlay_hwnd, &ww, &hh);
+#else
+	// Linux (#249): live geometry of the bound X11 window, same role as the
+	// macOS backing size above. Returns 0 when no window is bound (runtime
+	// self-hosting), which falls through to the display-info default below.
+	displayxr_linux_window_size(&ww, &hh);
 #endif
 	if (ww == 0 || hh == 0) {
 		ww = s_ps.display_info.is_valid ? s_ps.display_info.pixel_width : 1920;
@@ -4010,15 +4026,13 @@ int dxr_prov_session_start(const char *runtime_json_path,
 	                                : (is_d3d11 ? "XR_KHR_D3D11_enable" : "XR_KHR_D3D12_enable");
 	extensions[ext_count++] = XR_DXR_WIN32_WINDOW_BINDING_EXTENSION_NAME;
 #elif defined(__linux__) && !defined(__ANDROID__)
-	// Desktop Linux (#249): Vulkan only, same enable2 reasoning as above.
-	//
-	// NO window-binding extension in this phase. The runtime's Linux compositor can
-	// self-host its own XCB window (the shape the macOS bring-up used), and Unity
-	// exposes no X11 window handle through IUnityGraphics — so binding the player's
-	// own window would need a way to obtain it that does not exist yet.
-	// XR_DXR_xlib_window_binding / XR_DXR_wayland_surface_binding are registered
-	// runtime-side and are the follow-on once that handle is reachable.
+	// Desktop Linux (#249): Vulkan only, same enable2 reasoning as above, plus the
+	// xlib window binding so this is a HANDLE app like Windows and macOS — the
+	// runtime weaves into the player's own window. Requested unconditionally; if we
+	// cannot find the window at session-create we simply chain nothing and the
+	// runtime self-hosts (enabling an extension we then don't use is harmless).
 	extensions[ext_count++] = "XR_KHR_vulkan_enable2";
+	extensions[ext_count++] = XR_DXR_XLIB_WINDOW_BINDING_EXTENSION_NAME;
 #else
 	extensions[ext_count++] = XR_KHR_METAL_ENABLE_EXTENSION_NAME;
 	extensions[ext_count++] = XR_DXR_COCOA_WINDOW_BINDING_EXTENSION_NAME;
@@ -4350,21 +4364,42 @@ int dxr_prov_session_start(const char *runtime_json_path,
 		gfx_binding = &d3d12;
 	}
 #elif defined(ENABLE_VULKAN) && defined(__linux__) && !defined(__ANDROID__)
-	// --- Session: Vulkan graphics binding, NO window binding (#249 Phase 1) ---
+	// --- Session: Vulkan graphics binding + xlib window binding (#249) ---
 	//
-	// next == NULL means the runtime SELF-HOSTS its window: its Linux compositor
-	// creates its own XCB window and presents there (comp_vk_native_window_xcb).
-	// That is the same bring-up shape macOS used before the in-app NSView landed.
-	// Binding the player's own window instead needs XR_DXR_xlib_window_binding AND
-	// a way to get Unity's X11 window handle, which IUnityGraphics does not expose —
-	// that pair is the follow-on, not this phase.
-	const void *gfx_binding = dxr_pvk_session_binding(NULL);
+	// HANDLE app, same shape as Windows (HWND) and macOS (NSView): the runtime
+	// weaves into UNITY'S OWN window rather than creating one of its own.
+	// IUnityGraphics does not hand us the X11 window — exactly the gap macOS has
+	// for its NSView — so displayxr_linux.c finds it by walking the window tree
+	// for _NET_WM_PID == getpid(), the X11 analogue of walking NSApplication.
+	//
+	// If no window is found (no libX11, no DISPLAY, not yet mapped) we chain
+	// nothing and the runtime self-hosts an XCB window instead — degraded but
+	// still rendering, rather than failing the session.
+	XrXlibWindowBindingCreateInfoDXR xlib_binding = {};
+	const void *win_chain = NULL;
+	{
+		void *xdpy = NULL;
+		unsigned long xwin = 0;
+		if (displayxr_linux_get_weave_window(&xdpy, &xwin) && xdpy && xwin) {
+			xlib_binding.type = XR_TYPE_XLIB_WINDOW_BINDING_CREATE_INFO_DXR_PS;
+			xlib_binding.next = NULL;
+			xlib_binding.xDisplay = xdpy;
+			xlib_binding.window = xwin;
+			xlib_binding.transparentBackgroundEnabled = use_transparent ? 1 : 0;
+			win_chain = &xlib_binding;
+			ps_log("[DisplayXR-PROV] Linux: binding the runtime's weave to the PLUGIN-OWNED "
+			       "overlay window 0x%lx (transparent=%d)\n", xwin, (int)use_transparent);
+		} else {
+			ps_log("[DisplayXR-PROV] Linux: no overlay window available — the runtime will "
+			       "self-host its weave window\n");
+		}
+	}
+	const void *gfx_binding = dxr_pvk_session_binding(win_chain);
 	if (!gfx_binding) {
 		ps_log("[DisplayXR-PROV] Vulkan session binding unavailable\n");
 		dxr_prov_session_stop();
 		return 0;
 	}
-	(void)use_transparent; // no transparent-background path without a window binding
 #else
 	// --- Session: Metal graphics binding (client queue) + cocoa window binding ---
 	// viewHandle == NULL → the runtime self-hosts its NSWindow + CAMetalLayer (the


### PR DESCRIPTION
Follow-up to #250. **First light: the Unity Linux player renders stereo through the real Leia SR weaver on an Odyssey G90XF, Vulkan end to end.**

![crate on the Odyssey](https://github.com/DisplayXR/displayxr-unity/assets/placeholder)
*(screenshot in the issue thread — the birp-multipass crate, woven, on the panel)*

## The headline, and it settles #248

**Unity's `vk::Image::CreateImageViews` crash does NOT reproduce on Linux.** Unity created both XR render textures from our external-memory bridge images and rendered continuously. On Windows that is precisely where it dies with every provider-controllable input bisected away. **That Unity VK-XR defect is Windows-specific** — worth adding to `docs~/unity-bug-report-vk-xr-preinit.md`, because "reproduces on one OS only" is exactly what upstream triage asks.

## Four bugs, found only by running it

Three are mine, from #250. One is a gap CI structurally could not see.

**1. The `.so` could not load at all.** Two undefined symbols — I widened provider `#ifdef` blocks to Linux without auditing what they *called*. The systemic part: unlike MSVC and macOS's two-level namespace, **a Linux shared library links happily with dangling references** and only dies when the loader binds them. CI was green on a binary that died in `GfxStart`. Fixed with a `displayxr_linux.c` platform TU (macOS already ships the equivalent), a `__APPLE__` guard on the Metal call, **`-Wl,--no-undefined`** so it becomes a link error, and an `ldd -r` CI gate.

**2. Nothing polled XR events on Linux.** The native pump was `#ifdef _WIN32`; the C# fallback `#if UNITY_*_OSX`. Linux inherited neither, so the READY event was never consumed, `xrBeginSession` never called, and the session sat at **state 2 forever**. It looked completely healthy — session created, weaver holding our window, ~1800 pump ticks — with a blank panel and **zero bridge copies**. Linux has no AppKit constraint, so it now polls on the graphics thread like Windows.

**3. We bound the wrong window.** `XR_DXR_xlib_window_binding` hands the **runtime** presentation of the supplied window, so that window must not already carry a swapchain the app presents to — and Unity's main window does. Bound to Unity's window: black (both presenters fighting one surface), or empty with Unity's present suppressed. The plugin now creates its **own** overlay window and hands the runtime that — which is what Windows does (`WS_POPUP` overlay) and macOS does (its own NSView). Neither ever hands over the surface the engine renders to. *(Thanks for the steer that this should be a handle app — it was right, and the correction was that "handle" means our window, not Unity's.)*

**4. The overlay was covered.** `XRaiseWindow` is only a *request*; a reparenting WM restacks Unity's focused window back on top. The weave was live the whole time, visible only as a strip along the edges Unity's window didn't cover. The overlay is now **override-redirect** — the X11 equivalent of `WS_POPUP`.

## Also in here

- **libX11 is `dlopen`ed** — no `DT_NEEDED`, no `libx11-dev` in CI, and it degrades to runtime self-hosting if absent.
- The window search **retries** instead of latching an early failure (Unity's window may not be mapped when XR initializes).
- The overlay background is **magenta on purpose**, so "never presented" is visually distinct from "presented black" — with a black background those two look identical, which cost a debugging cycle.
- A periodic **bridge-copy log**: "the panel is black" was ambiguous between three very different bugs.
- The weave-target log no longer claims `SELFHOST` on Linux while the xlib-binding line two lines below says otherwise.

## Verification

| | |
|---|---|
| Linux x86_64 | `ubuntu:22.04` container — no undefined symbols, no `libvulkan`/`libX11` `DT_NEEDED` |
| macOS Universal | `build-mac.sh` |
| Windows x64 | MinGW cross-check |
| **Odyssey G90XF** | `api=Vulkan(enable2 bridge)`, Leia SR DP v2.0.7 + real srSDK weaver, session **FOCUSED**, `LeiaSR` mode `hw3d=1 views=2`, bridge copies running, **crate visible on the panel** |

## Known gaps (follow-ups, not blockers)

- **Input**: the overlay is override-redirect and takes clicks that would reach Unity. Windows solves this with `WS_EX_NOACTIVATE` + a click-through region; the X11 equivalent is an empty `XShape` **input** region (needs a libXext `dlopen`).
- wsui / Local2D / extra 3D zones / weave-to-texture remain inert on Linux by design.
- Hybrid-GPU Linux boxes still have no adapter-alignment lever (`DisplayXRGpuPreference` is DXGI-based); the session-side `deviceUUID` guard turns a mismatch into a loud refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)