### PR TITLE
ci(#249): force-add the Linux .so to the upm branch + guard against missing binaries

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -329,8 +329,29 @@ jobs:
                  launch-unity.sh launch-unity.sh.meta
 
           # Force-add the binaries (normally gitignored or absent).
+          # The Linux .so is the one binary that is NEVER committed to the
+          # repo (.gitignore: Runtime/Plugins/Linux/x86_64/*.so) — it exists
+          # here only because the build-linux artifact was downloaded into
+          # the working tree above. It was missing from this list when the
+          # Linux leg landed (#249), so v2.12.0's upm branch shipped only the
+          # .so.meta and git-URL installs got no Linux plugin, while the .tgz
+          # (packed with tar, which ignores .gitignore) was fine. Keep all
+          # three adds in sync with the download-artifact steps.
           git add -f Runtime/Plugins/Windows/x64/displayxr_unity.dll
           git add -f Runtime/Plugins/macOS/displayxr_unity.bundle
+          git add -f Runtime/Plugins/Linux/x86_64/libdisplayxr_unity.so
+
+          # Fail loudly rather than silently shipping an incomplete upm
+          # branch: every platform binary must be staged at this point.
+          for f in Runtime/Plugins/Windows/x64/displayxr_unity.dll \
+                   Runtime/Plugins/macOS/displayxr_unity.bundle/Contents/MacOS/displayxr_unity \
+                   Runtime/Plugins/Linux/x86_64/libdisplayxr_unity.so; do
+            git diff --cached --name-only | grep -qxF "$f" || \
+              git ls-files --error-unmatch "$f" >/dev/null 2>&1 || {
+                echo "::error::$f is not staged for the upm branch — refusing to publish an incomplete package."
+                exit 1
+              }
+          done
 
           # NOTE: deliberately NOT using `git add -A` here. The previous
           # job step ("Create UPM tarball") leaves an untracked staging


### PR DESCRIPTION
## Problem

Found while cutting **v2.12.0** (the first release shipping a Linux binary).

The release job's *Push upm branch with binaries* step force-adds only two binaries:

```
git add -f Runtime/Plugins/Windows/x64/displayxr_unity.dll
git add -f Runtime/Plugins/macOS/displayxr_unity.bundle
```

The Linux `.so` was never added to that list when the Linux leg landed (#249). It is
the one binary that is **never committed** to the repo (`.gitignore:43` →
`Runtime/Plugins/Linux/x86_64/*.so`), existing in CI only because the `build-linux`
artifact is downloaded into the working tree. The step deliberately avoids `git add -A`,
so the `.so` silently fell out.

Result on v2.12.0: the `upm` branch shipped `libdisplayxr_unity.so.meta` with **no
binary**, so `#upm` / `#upm/v2.12.0` git-URL installs got no Linux plugin at all. The
`.tgz` release asset was unaffected — it is packed with `tar`, which does not consult
`.gitignore`.

## Fix

- Force-add `Runtime/Plugins/Linux/x86_64/libdisplayxr_unity.so`.
- Add a guard that fails the release job if any of the three platform binaries is
  neither newly staged nor already tracked, so an incomplete `upm` branch can never be
  published silently again.

## Already repaired by hand

v2.12.0's `upm` branch and the `upm/v2.12.0` tag were fixed out-of-band (commit
`d1f0250`) with the ELF from the released tarball
(`BuildID 800b48be…`, 132200 bytes, verified `ELF 64-bit LSB shared object, x86-64`).
No re-release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)